### PR TITLE
Use default text coloring from console

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -57,7 +57,6 @@ export class YourComponent {
 ## Config Options
  * serverLogLevel - Only sends logs to the server for the level specified or higher (OFF disables the logger for the server)
  * serverLoggingUrl - URL to POST logs
- * enableDarkTheme: Sets the default color to white instead of black
  * level: The app will only log message for that level or higher (OFF disables the logger for the client)
 ```
 TRACE|DEBUG|INFO|LOG|WARN|ERROR|OFF

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "1.2.9",
+  "version": "1.0.0",
   "scripts": {
     "build": "gulp build",
     "build:watch": "gulp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "0.2.9",
+  "version": "1.2.9",
   "scripts": {
     "build": "gulp build",
     "build:watch": "gulp",

--- a/src/logger.service.ts
+++ b/src/logger.service.ts
@@ -9,7 +9,6 @@ export class LoggerConfig {
   level: NgxLoggerLevel;
   serverLogLevel: NgxLoggerLevel;
   serverLoggingUrl?: string;
-  enableDarkTheme?: boolean;
 }
 
 export enum NgxLoggerLevel {
@@ -143,30 +142,27 @@ export class NGXLogger {
       return this._logIE(level, message, additional);
     }
 
-    let color1;
+    const color = this._getColor(level);
 
+    console.log(`%c${this._timestamp()} [${Levels[level]}]`, `color:${color}`, message, ...additional);
+  }
+
+  private _getColor(level: NgxLoggerLevel) {
     switch (level) {
       case NgxLoggerLevel.TRACE:
-        color1 = 'blue';
-        break;
+        return 'blue';
       case NgxLoggerLevel.DEBUG:
-        color1 = 'teal';
-        break;
+        return 'teal';
       case NgxLoggerLevel.INFO:
       case NgxLoggerLevel.LOG:
-        color1 = 'gray';
-        break;
+        return 'gray';
       case NgxLoggerLevel.WARN:
       case NgxLoggerLevel.ERROR:
-        color1 = 'red';
-        break;
+        return 'red';
       case NgxLoggerLevel.OFF:
       default:
         return;
     }
-
-    const defaultColor = this.options.enableDarkTheme ? 'white' : 'black';
-    console.log(`%c${this._timestamp()} [${Levels[level]}] %c${message}`, `color:${color1}`, `color:${defaultColor}`, ...additional);
   }
 
 }

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "1.2.9",
+  "version": "1.0.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/dbfannin/ngx-logger"

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "0.2.9",
+  "version": "1.2.9",
   "repository": {
     "type": "git",
     "url": "https://github.com/dbfannin/ngx-logger"


### PR DESCRIPTION
This fixes #31 - Using the default color from console.  
Breaking changes:  
- `enableDarkTheme` option is no longer available.

Please check if new versioning is correct.. `0.2.9` to `1.2.9`.

Thanks