### PR TITLE
Feature/break apart service

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -4,6 +4,27 @@
 
 NGX Logger is a simple logging module for angular (currently supports angular 5.*). It allows "pretty print" to the console, as well as allowing log messages to be POSTed to a URL for server-side logging.
 
+
+## Latest Updates to NGX Logger
+
+ * Updating your config after importing the module has never been easier...
+ ```typescript
+    this.logger.updateConfig({level: NgxLoggerLevel.DEBUG});
+```
+ * You can now create a standalone logger with it's own config! 
+ ```typescript
+  export class MyService {
+    private logger: NGXLogger;
+    constructor(customLogger: CustomNGXLoggerService) {
+      this.logger = customLogger.create({level: NgxLoggerLevel.ERROR});
+    
+      this.logger.error('BLAHBLAHBLAH');
+    }
+  }
+    
+```
+ 
+ 
 ## Dependencies
  * @angular/common
  * @angular/core

--- a/README.MD
+++ b/README.MD
@@ -90,3 +90,24 @@ If serverLogginUrl exists, NGX Logger will attempt to POST that log to the serve
 
 Payload Example
 ```{level: 'DEBUG', message: 'Your log message goes here'}```
+
+
+## Testing your App when using NGXLogger
+If you inject the of the NGX Logger services into your application. you will need to provide it in your Testing Module.
+All services have mocked classes that can be used for testing
+
+* NGXLoggerHttpService: NGXLoggerHttpServiceMock
+* CustomNGXLoggerService: CustomNGXLoggerServiceMock
+* NGXLogger: NGXLoggerMock
+
+
+To provide them in your Testing Module
+```typescript
+     TestBed.configureTestingModule({
+       providers: [
+         {provide: NGXLogger, useCLass: NGXLoggerMock},
+         ...
+       ],
+       ...
+     });
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,6 +80,7 @@
         "colors": "1.1.2",
         "commander": "2.11.0",
         "findit": "2.0.0",
+        "fs-extra": "4.0.3",
         "glob": "7.1.2",
         "gulp-util": "3.0.8",
         "handlebars": "4.0.11",
@@ -95,6 +96,17 @@
         "typescript": "2.6.1"
       },
       "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        },
         "typescript": {
           "version": "2.6.1",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.1.tgz",
@@ -121,7 +133,21 @@
       "requires": {
         "@compodoc/ngd-core": "2.0.0-alpha.3",
         "dot": "1.1.2",
+        "fs-extra": "4.0.3",
         "viz.js": "1.8.0"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz",
+          "integrity": "sha512-q6rbdDd1o2mAnQreO7YADIxf/Whx4AHBiRf6d+/cVT8h44ss+lHgxf1FemcqDnQt9X3ct4McHr+JMGlYSsK7Cg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "jsonfile": "4.0.0",
+            "universalify": "0.1.1"
+          }
+        }
       }
     },
     "@types/jasmine": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "scripts": {
     "build": "gulp build",
     "build:watch": "gulp",

--- a/src/config.engine.ts
+++ b/src/config.engine.ts
@@ -1,0 +1,17 @@
+import {LoggerConfig} from './logger.config';
+
+export class NGXLoggerConfigEngine {
+
+  private _config;
+  constructor(readonly config: LoggerConfig) {
+    this._config = config;
+  }
+
+  updateConfig(config: LoggerConfig) {
+    this._config = config;
+  }
+
+  getConfig() {
+    return this._config;
+  }
+}

--- a/src/custom-logger.service.mock.ts
+++ b/src/custom-logger.service.mock.ts
@@ -1,0 +1,17 @@
+import {NGXLoggerMock} from './logger.service.mock';
+
+/**
+ * CustomNGXLoggerServiceMock is a mock for CustomNGXLoggerService
+ */
+export class CustomNGXLoggerServiceMock {
+
+  constructor() {
+  }
+
+  create(): NGXLoggerMock {
+    // you can inject your own httpService or use the default,
+    return new NGXLoggerMock();
+  }
+}
+
+

--- a/src/custom-logger.service.ts
+++ b/src/custom-logger.service.ts
@@ -1,0 +1,23 @@
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
+
+import {LoggerConfig} from './logger.config';
+import {NGXLoggerHttpService} from './http.service';
+import {NGXLogger} from './logger.service';
+
+
+/**
+ * CustomNGXLoggerService is designed to allow users to get a new instance of a logger
+ */
+@Injectable()
+export class CustomNGXLoggerService {
+
+  constructor(private readonly httpService: NGXLoggerHttpService, @Inject(PLATFORM_ID) private readonly platformId) {
+  }
+
+  getLogger(config: LoggerConfig, httpService?: NGXLoggerHttpService): NGXLogger {
+    // you can inject your own httpService or use the default,
+    return new NGXLogger(httpService || this.httpService, config, this.platformId);
+  }
+}
+
+

--- a/src/custom-logger.service.ts
+++ b/src/custom-logger.service.ts
@@ -14,7 +14,7 @@ export class CustomNGXLoggerService {
   constructor(private readonly httpService: NGXLoggerHttpService, @Inject(PLATFORM_ID) private readonly platformId) {
   }
 
-  getLogger(config: LoggerConfig, httpService?: NGXLoggerHttpService): NGXLogger {
+  create(config: LoggerConfig, httpService?: NGXLoggerHttpService): NGXLogger {
     // you can inject your own httpService or use the default,
     return new NGXLogger(httpService || this.httpService, config, this.platformId);
   }

--- a/src/http.service.mock.ts
+++ b/src/http.service.mock.ts
@@ -1,4 +1,5 @@
 import {Observable} from 'rxjs/Observable';
+import 'rxjs/add/observable/of';
 
 export class NGXLoggerHttpServiceMock {
   constructor() {
@@ -6,9 +7,6 @@ export class NGXLoggerHttpServiceMock {
   }
 
   logOnServer(url: string, message: string, additional: any[], timestamp: string, logLevel: string): Observable<any> {
-    return new Observable<any>(observer => {
-      observer.next({});
-      observer.complete();
-    })
+    return Observable.of({})
   }
 }

--- a/src/http.service.mock.ts
+++ b/src/http.service.mock.ts
@@ -1,0 +1,14 @@
+import {Observable} from 'rxjs/Observable';
+
+export class NGXLoggerHttpServiceMock {
+  constructor() {
+
+  }
+
+  logOnServer(url: string, message: string, additional: any[], timestamp: string, logLevel: string): Observable<any> {
+    return new Observable<any>(observer => {
+      observer.next({});
+      observer.complete();
+    })
+  }
+}

--- a/src/http.service.ts
+++ b/src/http.service.ts
@@ -1,5 +1,5 @@
 import {Injectable} from '@angular/core';
-import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
+import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Observable} from 'rxjs/Observable';
 
 

--- a/src/http.service.ts
+++ b/src/http.service.ts
@@ -1,0 +1,26 @@
+import {Injectable} from '@angular/core';
+import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
+import {Observable} from 'rxjs/Observable';
+
+
+@Injectable()
+export class NGXLoggerHttpService {
+  constructor(private readonly http: HttpClient) {
+
+  }
+
+  logOnServer(url: string, message: string, additional: any[] = [], timestamp: string, logLevel: string): Observable<any> {
+    const body = {
+      level: logLevel,
+      message: message,
+      additional: additional,
+      timestamp: timestamp
+    };
+
+    const options = {
+      headers: new HttpHeaders().set('Content-Type', 'application/json')
+    };
+
+    return this.http.post(url, body, options)
+  }
+}

--- a/src/http.service.ts
+++ b/src/http.service.ts
@@ -9,7 +9,7 @@ export class NGXLoggerHttpService {
 
   }
 
-  logOnServer(url: string, message: string, additional: any[] = [], timestamp: string, logLevel: string): Observable<any> {
+  logOnServer(url: string, message: string, additional: any[], timestamp: string, logLevel: string): Observable<any> {
     const body = {
       level: logLevel,
       message: message,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ import {NGXLoggerHttpService} from './http.service';
 export * from './http.service';
 
 export * from './types/logger-lever.enum';
-export * from './types/logger-level.map';
 
 @NgModule({
   imports: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,22 @@ import {CommonModule} from '@angular/common';
 import {HttpClientModule} from '@angular/common/http';
 import {ModuleWithProviders, NgModule} from '@angular/core';
 
-import {LoggerConfig, NGXLogger} from './logger.service';
-import {NGXLoggerMock} from './logger.service.mock';
-
+import {NGXLogger} from './logger.service';
 export * from './logger.service.mock';
 export * from './logger.service';
+
+import {LoggerConfig} from './logger.config';
+export * from './logger.config';
+
+import {CustomNGXLoggerService} from './custom-logger.service';
+export * from './custom-logger.service';
+
+
+import {NGXLoggerHttpService} from './http.service';
+export * from './http.service';
+
+export * from './types/logger-lever.enum';
+export * from './types/logger-level.map';
 
 @NgModule({
   imports: [
@@ -21,7 +32,8 @@ export class LoggerModule {
       providers: [
         {provide: LoggerConfig, useValue: config || {}},
         NGXLogger,
-        NGXLoggerMock
+        NGXLoggerHttpService,
+        CustomNGXLoggerService
       ]
     };
   }
@@ -30,7 +42,8 @@ export class LoggerModule {
       ngModule: LoggerModule,
       providers: [
         NGXLogger,
-        NGXLoggerMock
+        NGXLoggerHttpService,
+        CustomNGXLoggerService
       ]
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,10 +11,12 @@ export * from './logger.config';
 
 import {CustomNGXLoggerService} from './custom-logger.service';
 export * from './custom-logger.service';
+export * from './custom-logger.service.mock';
 
 
 import {NGXLoggerHttpService} from './http.service';
 export * from './http.service';
+export * from './http.service.mock';
 
 export * from './types/logger-lever.enum';
 

--- a/src/logger.config.ts
+++ b/src/logger.config.ts
@@ -1,0 +1,7 @@
+import {NgxLoggerLevel} from './types/logger-lever.enum';
+
+export class LoggerConfig {
+  level: NgxLoggerLevel;
+  serverLogLevel?: NgxLoggerLevel;
+  serverLoggingUrl?: string;
+}

--- a/src/logger.service.ts
+++ b/src/logger.service.ts
@@ -3,10 +3,20 @@ import {HttpErrorResponse} from '@angular/common/http';
 import {isPlatformBrowser} from '@angular/common';
 
 import {NGXLoggerHttpService} from './http.service';
-import {Levels} from './types/logger-level.map';
 import {NgxLoggerLevel} from './types/logger-lever.enum';
 import {LoggerConfig} from './logger.config';
 import {NGXLoggerConfigEngine} from './config.engine';
+
+export const Levels = [
+  'TRACE',
+  'DEBUG',
+  'INFO',
+  'LOG',
+  'WARN',
+  'ERROR',
+  'OFF'
+];
+
 
 @Injectable()
 export class NGXLogger {

--- a/src/logger.service.ts
+++ b/src/logger.service.ts
@@ -1,141 +1,72 @@
-import {Inject, Injectable, Optional, PLATFORM_ID} from '@angular/core';
-
-import {HttpClient, HttpErrorResponse, HttpHeaders} from '@angular/common/http';
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
+import {HttpErrorResponse} from '@angular/common/http';
 import {isPlatformBrowser} from '@angular/common';
 
-export class LoggerConfig {
-  level: NgxLoggerLevel;
-  serverLogLevel: NgxLoggerLevel;
-  serverLoggingUrl?: string;
-}
-
-export enum NgxLoggerLevel {
-  TRACE = 0, DEBUG, INFO, LOG, WARN, ERROR, OFF
-}
-
-const Levels = [
-  'TRACE',
-  'DEBUG',
-  'INFO',
-  'LOG',
-  'WARN',
-  'ERROR',
-  'OFF'
-];
+import {NGXLoggerHttpService} from './http.service';
+import {Levels} from './types/logger-level.map';
+import {NgxLoggerLevel} from './types/logger-lever.enum';
+import {LoggerConfig} from './logger.config';
+import {NGXLoggerConfigEngine} from './config.engine';
 
 @Injectable()
 export class NGXLogger {
-  private _serverLogLevel: NgxLoggerLevel;
-  private _clientLogLevel: NgxLoggerLevel;
   private _isIE: boolean;
+  private configService: NGXLoggerConfigEngine;
 
-  constructor(private readonly http: HttpClient, @Inject(PLATFORM_ID) private readonly platformId, @Optional() private readonly options?: LoggerConfig) {
-    this.options = this.options ? this.options : {
-      level: NgxLoggerLevel.OFF,
-      serverLogLevel: NgxLoggerLevel.OFF
-    };
-    this._serverLogLevel = this.options.serverLogLevel;
-    this._clientLogLevel = this.options.level;
+
+  constructor(private readonly httpService: NGXLoggerHttpService, loggerConfig: LoggerConfig, @Inject(PLATFORM_ID) private readonly platformId) {
     this._isIE = isPlatformBrowser(platformId) &&
-      !!(navigator.userAgent.indexOf('MSIE') !== -1 || navigator.userAgent.match(/Trident\//) || navigator.userAgent.match(/Edge\//));
+        !!(navigator.userAgent.indexOf('MSIE') !== -1 || navigator.userAgent.match(/Trident\//) || navigator.userAgent.match(/Edge\//));
+
+    // each instance of the logger should have their own config engine
+    this.configService = new NGXLoggerConfigEngine(loggerConfig);
   }
 
   public trace(message, ...additional: any[]): void {
-    this._log(NgxLoggerLevel.TRACE, true, message, additional);
+    this._log(NgxLoggerLevel.TRACE, message, additional);
   }
 
   public debug(message, ...additional: any[]): void {
-    this._log(NgxLoggerLevel.DEBUG, true, message, additional);
+    this._log(NgxLoggerLevel.DEBUG, message, additional);
   }
 
   public info(message, ...additional: any[]): void {
-    this._log(NgxLoggerLevel.INFO, true, message, additional);
+    this._log(NgxLoggerLevel.INFO, message, additional);
   }
 
   public log(message, ...additional: any[]): void {
-    this._log(NgxLoggerLevel.LOG, true, message, additional);
+    this._log(NgxLoggerLevel.LOG, message, additional);
   }
 
   public warn(message, ...additional: any[]): void {
-    this._log(NgxLoggerLevel.WARN, true, message, additional);
+    this._log(NgxLoggerLevel.WARN, message, additional);
   }
 
   public error(message, ...additional: any[]): void {
-    this._log(NgxLoggerLevel.ERROR, true, message, additional);
+    this._log(NgxLoggerLevel.ERROR, message, additional);
   }
 
-  private _timestamp(): string {
-    return new Date().toISOString();
+  public updateConfig(config: LoggerConfig) {
+    this.configService.updateConfig(config);
   }
 
-  private _logOnServer(level: NgxLoggerLevel, message, additional: any[] = []): void {
-    // If the loggingUrl is not set or if the user provides a serverLogLevel and the current level is than that, do not log.
-    if (!this.options.serverLoggingUrl || level < this._serverLogLevel) {
-      return;
-    }
-
-    const headers = new HttpHeaders().set('Content-Type', 'application/json');
-
-    let messageToLog = '';
-
-    try {
-      messageToLog = JSON.stringify(message);
-    } catch (e) {
-      messageToLog = 'The provided "message" value could not be parsed with JSON.stringify().';
-    }
-
-    let additionalToLog: Array<string | null | undefined> = [];
-
-    if (additional === null || additional === undefined) {
-      additionalToLog = [];
-    } else {
-      additionalToLog = additional.map((val: any, idx: number) => {
-        try {
-          return val === null || val === undefined || typeof val === 'string' ? val
-            : JSON.stringify(val, null, 2);
-        } catch (e) {
-          return `The additional[${idx}] value could not be parsed using JSON.stringify().`;
-        }
-      });
-    }
-
-    this.http.post(this.options.serverLoggingUrl,
-      {
-        level: Levels[level],
-        message: messageToLog,
-        additional: additionalToLog,
-        timestamp: this._timestamp()
-      },
-      {
-        headers
-      })
-      .subscribe(
-        (res: any) => this._log(NgxLoggerLevel.TRACE, false, 'Server logging successful', [res]),
-        (error: HttpErrorResponse) => this._log(NgxLoggerLevel.ERROR, false, 'FAILED TO LOG ON SERVER', [error])
-      );
-  }
-
-  private _logIE(level: NgxLoggerLevel, message: string, additional: any[] = []): void {
+  private _logIE(level: NgxLoggerLevel, message: string, additional: any[] = [], timestamp: string): void {
     switch (level) {
       case NgxLoggerLevel.WARN:
-        console.warn(`${this._timestamp()} [${Levels[level]}] `, message, ...additional);
+        console.warn(`${timestamp} [${Levels[level]}] `, message, ...additional);
         break;
       case NgxLoggerLevel.ERROR:
-        console.error(`${this._timestamp()} [${Levels[level]}] `, message, ...additional);
+        console.error(`${timestamp} [${Levels[level]}] `, message, ...additional);
         break;
       case NgxLoggerLevel.INFO:
-        console.info(`${this._timestamp()} [${Levels[level]}] `, message, ...additional);
+        console.info(`${timestamp} [${Levels[level]}] `, message, ...additional);
         break;
       default:
-        console.log(`${this._timestamp()} [${Levels[level]}] `, message, ...additional);
+        console.log(`${timestamp} [${Levels[level]}] `, message, ...additional);
     }
   }
 
-  private _log(level: NgxLoggerLevel, logOnServer: boolean, message, additional: any[] = []): void {
-    if (!message) {
-      return;
-    }
-
+  private _prepareMessage(message) {
     try {
       if (message instanceof Error) {
         message = message.stack;
@@ -143,28 +74,74 @@ export class NGXLogger {
         message = JSON.stringify(message, null, 2);
       }
     } catch (e) {
-      additional = [message, ...additional];
+      // additional = [message, ...additional];
       message = 'The provided "message" value could not be parsed with JSON.stringify().';
     }
 
-    // Allow logging on server even if client log level is off
-    if (logOnServer) {
-      this._logOnServer(level, message, additional);
+    return message;
+  }
+
+  private _prepareAdditionalParameters(additional: any[]) {
+    if (additional === null || additional === undefined) {
+      return [];
     }
 
+    const additionalParams: any[] = [];
+
+    for (let i = 0; i < additional.length; i++) {
+      try {
+        if (typeof additional[i] === 'object') {
+          additional[i] = JSON.stringify(additional[i], null, 2);
+        }
+
+        additionalParams.push(additional[i]);
+      } catch (e) {
+        additionalParams.push(`The additional[${i}] value could not be parsed using JSON.stringify().`);
+      }
+    }
+
+    return additionalParams;
+  }
+
+  private _log(level: NgxLoggerLevel, message, additional: any[] = [], logOnServer: boolean = true): void {
+    if (!message) {
+      return;
+    }
+
+    const logLevelString = Levels[level];
+
+    message = this._prepareMessage(message);
+
+    additional = this._prepareAdditionalParameters(additional);
+
+    const timestamp = new Date().toISOString();
+    const config = this.configService.getConfig();
+
+    if (logOnServer && config.serverLoggingUrl && level >= config.serverLogLevel) {
+      // Allow logging on server even if client log level is off
+      this.httpService.logOnServer(config.serverLoggingUrl, message, additional, timestamp, logLevelString).subscribe((res: any) => {
+            // I don't think we should do anything on success
+          },
+          (error: HttpErrorResponse) => {
+            this._log(NgxLoggerLevel.ERROR, `FAILED TO LOG ON SERVER: ${message}`, [error], false);
+          }
+      );
+    }
+
+
     // if no message or the log level is less than the environ
-    if (level < this._clientLogLevel) {
+    if (level < config.level) {
       return;
     }
 
     // Coloring doesn't work in IE
     if (this._isIE) {
-      return this._logIE(level, message, additional);
+      return this._logIE(level, message, additional, timestamp);
     }
 
     const color = this._getColor(level);
 
-    console.log(`%c${this._timestamp()} [${Levels[level]}]`, `color:${color}`, message, ...additional);
+    console.log(`%c${timestamp} [${logLevelString}]`, `color:${color}`, message, ...additional);
   }
 
   private _getColor(level: NgxLoggerLevel): 'blue' | 'teal' | 'gray' | 'red' | undefined {

--- a/src/logger.service.ts
+++ b/src/logger.service.ts
@@ -96,21 +96,14 @@ export class NGXLogger {
       return [];
     }
 
-    const additionalParams: any[] = [];
-
-    for (let i = 0; i < additional.length; i++) {
+    return additional.map((next, idx) => {
       try {
-        if (typeof additional[i] === 'object') {
-          additional[i] = JSON.stringify(additional[i], null, 2);
-        }
-
-        additionalParams.push(additional[i]);
-      } catch (e) {
-        additionalParams.push(`The additional[${i}] value could not be parsed using JSON.stringify().`);
+        return typeof next === 'object' ? JSON.stringify(next, null, 2) : next;
       }
-    }
-
-    return additionalParams;
+      catch (e) {
+        return `The additional[${idx}] value could not be parsed using JSON.stringify().`
+      }
+    });
   }
 
   private _log(level: NgxLoggerLevel, message, additional: any[] = [], logOnServer: boolean = true): void {

--- a/src/logger.service.ts
+++ b/src/logger.service.ts
@@ -60,7 +60,11 @@ export class NGXLogger {
     this.configService.updateConfig(config);
   }
 
-  private _logIE(level: NgxLoggerLevel, message: string, additional: any[] = [], timestamp: string): void {
+  private _logIE(level: NgxLoggerLevel, message: string, additional: any[], timestamp: string): void {
+
+    // make sure additional isn't null or undefined so that ...additional doesn't error
+    additional = additional || [];
+
     switch (level) {
       case NgxLoggerLevel.WARN:
         console.warn(`${timestamp} [${Levels[level]}] `, message, ...additional);
@@ -93,7 +97,7 @@ export class NGXLogger {
 
   private _prepareAdditionalParameters(additional: any[]) {
     if (additional === null || additional === undefined) {
-      return [];
+      return null;
     }
 
     return additional.map((next, idx) => {
@@ -144,7 +148,7 @@ export class NGXLogger {
 
     const color = this._getColor(level);
 
-    console.log(`%c${timestamp} [${logLevelString}]`, `color:${color}`, message, ...additional);
+    console.log(`%c${timestamp} [${logLevelString}]`, `color:${color}`, message, ...(additional || []));
   }
 
   private _getColor(level: NgxLoggerLevel): 'blue' | 'teal' | 'gray' | 'red' | undefined {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "2.0.5",
+  "version": "2.1.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/dbfannin/ngx-logger"

--- a/src/types/logger-level.map.ts
+++ b/src/types/logger-level.map.ts
@@ -1,0 +1,9 @@
+export const Levels = [
+  'TRACE',
+  'DEBUG',
+  'INFO',
+  'LOG',
+  'WARN',
+  'ERROR',
+  'OFF'
+];

--- a/src/types/logger-level.map.ts
+++ b/src/types/logger-level.map.ts
@@ -1,9 +1,0 @@
-export const Levels = [
-  'TRACE',
-  'DEBUG',
-  'INFO',
-  'LOG',
-  'WARN',
-  'ERROR',
-  'OFF'
-];

--- a/src/types/logger-lever.enum.ts
+++ b/src/types/logger-lever.enum.ts
@@ -1,0 +1,3 @@
+export enum NgxLoggerLevel {
+  TRACE = 0, DEBUG, INFO, LOG, WARN, ERROR, OFF
+}


### PR DESCRIPTION
This breaks apart the logger service. it was getting too big, and doing too many things. 

This change also supports dynamically changing the logger config #24, and creating new instances of the logger which could solve the use case for #30.