### PR TITLE
arbitrary objects 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "scripts": {
     "build": "gulp build",
     "build:watch": "gulp",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,6 @@ import {CustomNGXLoggerService} from './custom-logger.service';
 export * from './custom-logger.service';
 export * from './custom-logger.service.mock';
 
-
 import {NGXLoggerHttpService} from './http.service';
 export * from './http.service';
 export * from './http.service.mock';

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/dbfannin/ngx-logger"


### PR DESCRIPTION
Allow arbitrary objects to be logged to console (this will allow circular objects to be parsed), but not to HTTP Service