### PR TITLE
Custom Log Monitoring

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 
 # NGX Logger
 
-NGX Logger is a simple logging module for angular (currently supports angular 5.\*). It allows "pretty print" to the console, as well as allowing log messages to be POSTed to a URL for server-side logging.
+NGX Logger is a simple logging module for angular (currently supports angular 6.\*). It allows "pretty print" to the console, as well as allowing log messages to be POSTed to a URL for server-side logging.
 
 ## Latest Updates to NGX Logger
 
@@ -158,7 +158,7 @@ to have the demo built and served.
 
 All are welcome to contribute to NGX Logger. A couple quick notes to get started..
 
-- NGX Logger is built with https://github.com/jvandemo/generator-angular2-library
+- NGX Logger is built with angular-cli
 - To use npm link, you must link the /src (or /dist after it is built) directory not root.
 - When possible, try to follow patterns that have already been established in the library
 - Try to make your code as simple as possible

--- a/README.MD
+++ b/README.MD
@@ -6,6 +6,32 @@ NGX Logger is a simple logging module for angular (currently supports angular 5.
 
 ## Latest Updates to NGX Logger
 
+- Custom Log Monitoring is now available
+```typescript
+import {NGXLoggerMonitor, NGXLogInterface} from 'ngx-logger';
+
+export class MyLoggerMonitor implements NGXLoggerMonitor {
+  onLog(log: NGXLogInterface) {
+    console.log('myCustomLoggerMonitor', log);
+  }
+}
+```
+
+```typescript
+import {NGXLogger} from 'ngx-logger';
+import {MyLoggerMonitor} from './my-logger-monitor';
+
+export class MyService {
+  constructor(private logger: NGXLogger) {
+    this.logger.registerMonitor(new MyLoggerMonitor())
+
+    this.logger.error('BLAHBLAHBLAH');
+  }
+}
+```
+
+
+
 - Updating your config after importing the module has never been easier...
 
 

--- a/README.MD
+++ b/README.MD
@@ -7,6 +7,8 @@ NGX Logger is a simple logging module for angular (currently supports angular 6.
 ## Latest Updates to NGX Logger
 
 - Custom Log Monitoring is now available
+    - Only 1 monitor can be registered at a time, registering a new monitor overwrites the previous monitor
+    - This should be registered as soon as possible so that it does not miss any logs.
 ```typescript
 import {NGXLoggerMonitor, NGXLogInterface} from 'ngx-logger';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/lib/custom-logger.service.ts
+++ b/src/lib/custom-logger.service.ts
@@ -3,6 +3,7 @@ import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
 import {LoggerConfig} from './logger.config';
 import {NGXLoggerHttpService} from './http.service';
 import {NGXLogger} from './logger.service';
+import {NGXLoggerMonitor} from './logger-monitor';
 
 
 /**
@@ -15,9 +16,15 @@ export class CustomNGXLoggerService {
               @Inject(PLATFORM_ID) private readonly platformId) {
   }
 
-  create(config: LoggerConfig, httpService?: NGXLoggerHttpService): NGXLogger {
+  create(config: LoggerConfig, httpService?: NGXLoggerHttpService, logMonitor?: NGXLoggerMonitor): NGXLogger {
     // you can inject your own httpService or use the default,
-    return new NGXLogger(httpService || this.httpService, config, this.platformId);
+    const logger = new NGXLogger(httpService || this.httpService, config, this.platformId);
+
+    if (logMonitor) {
+      logger.registerMonitor(logMonitor);
+    }
+
+    return logger;
   }
 }
 

--- a/src/lib/http.service.ts
+++ b/src/lib/http.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {HttpClient, HttpHeaders} from '@angular/common/http';
 import {Observable} from 'rxjs';
-import {HttpMetaDataInterface} from './types/http-meta-data.interface';
+import {NGXLogInterface} from './types/ngx-log.interface';
 
 
 @Injectable()
@@ -10,20 +10,12 @@ export class NGXLoggerHttpService {
 
   }
 
-  logOnServer(url: string, message: string, additional: any[], metaData: HttpMetaDataInterface): Observable<any> {
-    const body = {
-      message: message,
-      additional: additional,
-      level: metaData.level,
-      timestamp: metaData.timestamp,
-      fileName: metaData.fileName,
-      lineNumber: metaData.lineNumber
-    };
+  logOnServer(url: string, log: NGXLogInterface): Observable<any> {
 
     const options = {
       headers: new HttpHeaders().set('Content-Type', 'application/json')
     };
 
-    return this.http.post(url, body, options)
+    return this.http.post(url, log, options);
   }
 }

--- a/src/lib/logger-monitor.ts
+++ b/src/lib/logger-monitor.ts
@@ -1,0 +1,8 @@
+import {NGXLogInterface} from './types/ngx-log.interface';
+
+export class NGXLoggerMonitor {
+
+  onLog(logObject: NGXLogInterface) {
+
+  }
+}

--- a/src/lib/logger-monitor.ts
+++ b/src/lib/logger-monitor.ts
@@ -1,8 +1,5 @@
 import {NGXLogInterface} from './types/ngx-log.interface';
 
-export class NGXLoggerMonitor {
-
-  onLog(logObject: NGXLogInterface) {
-
-  }
+export abstract class NGXLoggerMonitor {
+  abstract onLog(logObject: NGXLogInterface): void;
 }

--- a/src/lib/logger.module.ts
+++ b/src/lib/logger.module.ts
@@ -13,11 +13,13 @@ export * from './logger.config';
 
 export * from './custom-logger.service';
 
+export * from './logger-monitor';
+
 export * from './http.service';
 
 export * from './utils/logger.utils';
 export * from './types/logger-level.enum';
-export * from './types/http-meta-data.interface';
+export * from './types/ngx-log.interface';
 
 @NgModule({
   imports: [

--- a/src/lib/types/ngx-log.interface.ts
+++ b/src/lib/types/ngx-log.interface.ts
@@ -1,8 +1,11 @@
 import {NgxLoggerLevel} from './logger-level.enum';
 
-export class HttpMetaDataInterface {
+export class NGXLogInterface {
   level: NgxLoggerLevel;
   timestamp: string;
   fileName: string;
   lineNumber: string;
+
+  message: string;
+  additional: any[];
 }


### PR DESCRIPTION
users have been requesting the ability to do manual log monitoring. This adds the ability register a custom logger which will be passed all logs that pass the log level threshold.