### PR TITLE
Support For Custom http params to extend http options

### DIFF
--- a/src/lib/http.service.ts
+++ b/src/lib/http.service.ts
@@ -1,7 +1,8 @@
-import {Injectable} from '@angular/core';
-import {HttpClient, HttpHeaders} from '@angular/common/http';
-import {Observable} from 'rxjs';
-import {NGXLogInterface} from './types/ngx-log.interface';
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { NGXLogInterface } from './types/ngx-log.interface';
+
 
 
 @Injectable()
@@ -10,14 +11,34 @@ export class NGXLoggerHttpService {
 
   }
 
-  logOnServer(url: string, log: NGXLogInterface, customHeaders: HttpHeaders): Observable<any> {
+  // logOnServer(url: string, log: NGXLogInterface, customHeaders: HttpHeaders, customParams?: HttpParams): Observable<any> {
+  //   const headers = customHeaders || new HttpHeaders();
+  //   const params = customParams || new HttpParams();
+  //   headers.set('Content-Type', 'application/json');
+
+  //   const options = {
+  //     headers: headers,
+  //     params: params
+  //   };
+
+
+  //   return this.http.post(url, log, options);
+  // }
+
+  logOnServer(url: string, log: NGXLogInterface, options: object): Observable<any> {
+    return this.http.post(url, log, options || {});
+  }
+
+
+  setHeaders(customHeaders?: HttpHeaders): HttpHeaders {
     const headers = customHeaders || new HttpHeaders();
     headers.set('Content-Type', 'application/json');
-
-    const options = {
-      headers: headers
-    };
-
-    return this.http.post(url, log, options);
+    return headers;
   }
+
+  setParams(customParams?: HttpParams): HttpParams {
+    const params = customParams || new HttpParams();
+    return params;
+  }
+
 }

--- a/src/lib/http.service.ts
+++ b/src/lib/http.service.ts
@@ -11,24 +11,9 @@ export class NGXLoggerHttpService {
 
   }
 
-  // logOnServer(url: string, log: NGXLogInterface, customHeaders: HttpHeaders, customParams?: HttpParams): Observable<any> {
-  //   const headers = customHeaders || new HttpHeaders();
-  //   const params = customParams || new HttpParams();
-  //   headers.set('Content-Type', 'application/json');
-
-  //   const options = {
-  //     headers: headers,
-  //     params: params
-  //   };
-
-
-  //   return this.http.post(url, log, options);
-  // }
-
   logOnServer(url: string, log: NGXLogInterface, options: object): Observable<any> {
     return this.http.post(url, log, options || {});
   }
-
 
   setHeaders(customHeaders?: HttpHeaders): HttpHeaders {
     const headers = customHeaders || new HttpHeaders();

--- a/src/lib/http.service.ts
+++ b/src/lib/http.service.ts
@@ -7,23 +7,10 @@ import { NGXLogInterface } from './types/ngx-log.interface';
 
 @Injectable()
 export class NGXLoggerHttpService {
-  constructor(private readonly http: HttpClient) {
-
-  }
+  constructor(private readonly http: HttpClient) { }
 
   logOnServer(url: string, log: NGXLogInterface, options: object): Observable<any> {
     return this.http.post(url, log, options || {});
-  }
-
-  setHeaders(customHeaders?: HttpHeaders): HttpHeaders {
-    const headers = customHeaders || new HttpHeaders();
-    headers.set('Content-Type', 'application/json');
-    return headers;
-  }
-
-  setParams(customParams?: HttpParams): HttpParams {
-    const params = customParams || new HttpParams();
-    return params;
   }
 
 }

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -1,14 +1,14 @@
-import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
-import {HttpErrorResponse, HttpHeaders} from '@angular/common/http';
-import {isPlatformBrowser} from '@angular/common';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
+import { isPlatformBrowser } from '@angular/common';
 
-import {NGXLoggerHttpService} from './http.service';
-import {NgxLoggerLevel} from './types/logger-level.enum';
-import {LoggerConfig} from './logger.config';
-import {NGXLoggerConfigEngine} from './config.engine';
-import {NGXLoggerUtils} from './utils/logger.utils';
-import {NGXLoggerMonitor} from './logger-monitor';
-import {NGXLogInterface} from './types/ngx-log.interface';
+import { NGXLoggerHttpService } from './http.service';
+import { NgxLoggerLevel } from './types/logger-level.enum';
+import { LoggerConfig } from './logger.config';
+import { NGXLoggerConfigEngine } from './config.engine';
+import { NGXLoggerUtils } from './utils/logger.utils';
+import { NGXLoggerMonitor } from './logger-monitor';
+import { NGXLogInterface } from './types/ngx-log.interface';
 
 export const Levels = [
   'TRACE',
@@ -28,11 +28,12 @@ export class NGXLogger {
   private readonly _logFunc: Function;
   private configService: NGXLoggerConfigEngine;
   private _customHttpHeaders: HttpHeaders;
+  private _customParams: HttpParams;
 
   private _loggerMonitor: NGXLoggerMonitor;
 
   constructor(private readonly httpService: NGXLoggerHttpService, loggerConfig: LoggerConfig,
-              @Inject(PLATFORM_ID) private readonly platformId) {
+    @Inject(PLATFORM_ID) private readonly platformId) {
     this._isIE = isPlatformBrowser(platformId) &&
       !!(navigator.userAgent.indexOf('MSIE') !== -1 || navigator.userAgent.match(/Trident\//) || navigator.userAgent.match(/Edge\//));
 
@@ -73,6 +74,10 @@ export class NGXLogger {
 
   public setCustomHttpHeaders(headers: HttpHeaders) {
     this._customHttpHeaders = headers;
+  }
+
+  public setCustomParams(params: HttpParams) {
+    this._customParams = params;
   }
 
   public registerMonitor(monitor: NGXLoggerMonitor) {
@@ -181,10 +186,14 @@ export class NGXLogger {
 
       logObject.message = message;
 
+      const options = {
+        headers: this.httpService.setHeaders(this._customHttpHeaders),
+        params: this.httpService.setParams(this._customParams)
+      };
       // Allow logging on server even if client log level is off
-      this.httpService.logOnServer(config.serverLoggingUrl, logObject, this._customHttpHeaders).subscribe((res: any) => {
-          // I don't think we should do anything on success
-        },
+      this.httpService.logOnServer(config.serverLoggingUrl, logObject, options).subscribe((res: any) => {
+        // I don't think we should do anything on success
+      },
         (error: HttpErrorResponse) => {
           this._log(NgxLoggerLevel.ERROR, `FAILED TO LOG ON SERVER: ${message}`, [error], false);
         }

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -183,12 +183,14 @@ export class NGXLogger {
     if (isLog2Server) {
       // make sure the stack gets sent to the server
       message = message instanceof Error ? message.stack : message;
-
       logObject.message = message;
 
+      const headers = this._customHttpHeaders || new HttpHeaders();
+      headers.set('Content-Type', 'application/json');
+
       const options = {
-        headers: this.httpService.setHeaders(this._customHttpHeaders),
-        params: this.httpService.setParams(this._customParams)
+        headers: headers,
+        params: this._customParams || new HttpParams()
       };
       // Allow logging on server even if client log level is off
       this.httpService.logOnServer(config.serverLoggingUrl, logObject, options).subscribe((res: any) => {


### PR DESCRIPTION
[Added][Support for custom params, to pass metadata along with the request]
- to pass any additional metadata along with request
- example, hide loader in case of "ngx-logger" network call
