### PR TITLE
fix(sourceMaps): Improve parsing of stackLine for extracting source file location

### DIFF
--- a/src/lib/mapper.service.ts
+++ b/src/lib/mapper.service.ts
@@ -37,7 +37,13 @@ export class NGXMapperService {
 
   private static getPosition(stackLine: string): LogPosition {
     // strip base path, then parse filename, line, and column
-    const position = stackLine.substring(stackLine.lastIndexOf('\/') + 1, stackLine.indexOf(')'));
+    const positionStartIndex = stackLine.lastIndexOf('\/');
+    let positionEndIndex = stackLine.indexOf(')');
+    if (positionEndIndex < 0) {
+      positionEndIndex = undefined;
+    }
+
+    const position = stackLine.substring(positionStartIndex + 1, positionEndIndex);
     const dataArray = position.split(':');
     if (dataArray.length === 3) {
       return new LogPosition(dataArray[0], +dataArray[1], +dataArray[2]);
@@ -46,7 +52,17 @@ export class NGXMapperService {
   }
 
   private static getTranspileLocation(stackLine: string): string {
-    return stackLine.substring(stackLine.indexOf('(') + 1, stackLine.indexOf(')'));
+    let locationStartIndex = stackLine.indexOf('(');
+    if (locationStartIndex < 0) {
+      locationStartIndex = stackLine.lastIndexOf(' ');
+    }
+
+    let locationEndIndex = stackLine.indexOf(')');
+    if (locationEndIndex < 0) {
+      locationEndIndex = undefined;
+    }
+
+    return stackLine.substring(locationStartIndex + 1, locationEndIndex);
   }
 
   private static getMapFilePath(stackLine: string): string {

--- a/testing/src/lib/http.service.mock.ts
+++ b/testing/src/lib/http.service.mock.ts
@@ -6,6 +6,6 @@ export class NGXLoggerHttpServiceMock {
   }
 
   logOnServer(url: string, message: string, additional: any[], timestamp: string, logLevel: string): Observable<any> {
-    return of({})
+    return of({});
   }
 }


### PR DESCRIPTION
When source maps are activated, the call stack is analyzed to determine the log location. In version `4.0.5` it is assumed that the `stackLine` looks like this:

```
at myService.push../src/app/shared/my.service.ts.MyService.foo (http://localhost:4200/ui/main.js:2525:25)
```

With reference to issue #148, it is also possible that the file location is found in the call stack as follows:

```
at http://localhost:4200/ui/main.js:2525:25
```

This pull request adapts the parsing of the `stackLine` to fix issue #148.