### PR TITLE
Custom timestamp - fixes #96

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -10,10 +10,10 @@ As open source projects grow, they become more and more work to maintain. Featur
 
 
 ## Breaking changes for NGX Logger 3.* to 4.*
-- Importing mocks and the logger testing module should now be imported from the new testing entrypoint 
+- Importing mocks and the logger testing module should now be imported from the new testing entrypoint
    - `import {LoggerTestingModule} from 'ngx-logger/testing';`
-   
-   
+
+
 ## Latest Updates to NGX Logger
 - Support to set WithCredentials on your HTTP requests.
 ```typescript
@@ -21,15 +21,15 @@ this.logger.setWithCredentialsOptionValue(true);
 ```
 
 - Support for custom parsing of source maps. In order to use it, you must set **enableSourceMaps: true** in your logger config
-  - Note: In order for the enableSourceMaps flag to work, your app must generate the source maps during the build process. If your using AngularCli you can generate Source Maps by setting **"sourceMap": {"scripts": true}** (or for older version of angularCli **"sourceMap": true**) in your angular.json 
+  - Note: In order for the enableSourceMaps flag to work, your app must generate the source maps during the build process. If your using AngularCli you can generate Source Maps by setting **"sourceMap": {"scripts": true}** (or for older version of angularCli **"sourceMap": true**) in your angular.json
 
-- Support of responseType for HTTP Requests. A new config option *httpResponseType* now allows you to set your server's response type. 
+- Support of responseType for HTTP Requests. A new config option *httpResponseType* now allows you to set your server's response type.
 
 - Custom HTTP Params
     - If you need to pass in custom HTTP Params to your backend server, you can now use `setCustomParams()`.
 ```typescript
   this.logger.setCustomParams(new HttpParams());
-```  
+```
 
 - Using the NGXLoggerMonitor and want to disable console logs? Now you can!
     - New config option disableConsoleLogging will disable console logs, but still alert to the log monitor.
@@ -38,7 +38,7 @@ this.logger.setWithCredentialsOptionValue(true);
     - If you use an auth token, or need to pass in a custom header, now you can!
 ```typescript
   this.logger.setCustomHttpHeaders(new HttpHeaders({'X-Custom-Header': '123456'}));
-```  
+```
 
 - Custom Log Monitoring is now available.
     - Only one monitor can be registered at a time; registering a new monitor overwrites the previous monitor.
@@ -143,7 +143,8 @@ export class YourComponent {
 - serverLoggingUrl {string}: URL to POST logs.
 - httpResponseType {'arraybuffer' | 'blob' | 'text' | 'json'}: the response type of the HTTP Logging request.
 - enableSourceMaps {boolean}: enables manual parsing of Source Maps
-   - Note: In order for the enableSourceMaps flag to work, your app must generate the source maps during the build process. If your using AngularCli you can generate Source Maps by setting **"sourceMap": {"scripts": true}** (or for older version of angularCli **"sourceMap": true**) in your angular.json 
+   - Note: In order for the enableSourceMaps flag to work, your app must generate the source maps during the build process. If your using AngularCli you can generate Source Maps by setting **"sourceMap": {"scripts": true}** (or for older version of angularCli **"sourceMap": true**) in your angular.json
+- timestampFormatter {(Date) => string}: custom formatter for timestamps
 
 
 NgxLoggerLevels: `TRACE|DEBUG|INFO|LOG|WARN|ERROR|FATAL|OFF`

--- a/src/lib/logger.config.ts
+++ b/src/lib/logger.config.ts
@@ -7,4 +7,6 @@ export class LoggerConfig {
   disableConsoleLogging?: boolean;
   httpResponseType?: 'arraybuffer' | 'blob' | 'text' | 'json';
   enableSourceMaps?: boolean;
+  /** Custom timestamp formatter. Defaults to toISOString if undefined */
+  timestampFormatter?: (Date) => string;
 }

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -171,7 +171,10 @@ export class NGXLogger {
     // only use validated parameters for HTTP requests
     const validatedAdditionalParameters = NGXLoggerUtils.prepareAdditionalParameters(additional);
 
-    const timestamp = new Date().toISOString();
+    /** Use custom timestamp when provided in the config, defaults to toISOString */
+    const timestamp = config.timestampFormatter ?
+      config.timestampFormatter(new Date()) :
+      new Date().toISOString();
 
     // const callerDetails = NGXLoggerUtils.getCallerDetails();
     this.mapperService.getCallerDetails(config.enableSourceMaps).subscribe((callerDetails: LogPosition) => {


### PR DESCRIPTION
Following up on https://github.com/dbfannin/ngx-logger/issues/96, implemented the simple solution to give a custom callback to the config object.

It allows to use any formatting library (for example https://momentjs.com) without making the library bigger.

Fallbacks to current behaviour if the optional config argument is not given.