### PR TITLE
Customize timestamp - fixes #96 #149

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -143,7 +143,8 @@ export class YourComponent {
 - serverLoggingUrl {string}: URL to POST logs.
 - httpResponseType {'arraybuffer' | 'blob' | 'text' | 'json'}: the response type of the HTTP Logging request.
 - enableSourceMaps {boolean}: enables manual parsing of Source Maps
-   - Note: In order for the enableSourceMaps flag to work, your app must generate the source maps during the build process. If your using AngularCli you can generate Source Maps by setting **"sourceMap": {"scripts": true}** (or for older version of angularCli **"sourceMap": true**) in your angular.json 
+   - Note: In order for the enableSourceMaps flag to work, your app must generate the source maps during the build process. If your using AngularCli you can generate Source Maps by setting **"sourceMap": {"scripts": true}** (or for older version of angularCli **"sourceMap": true**) in your angular.json
+- timestampFormat {'short' | 'medium' | 'long' | 'full' | 'shortDate' | 'mediumDate' | 'longDate' | 'fullDate' | 'shortTime' | 'mediumTime' | 'longTime' | 'fullTime'}: format for the timestamp displayed with each log message. Can be any of the classic formatting options from the Angular [DatePipe](https://angular.io/api/common/DatePipe#pre-defined-format-options).
 
 
 NgxLoggerLevels: `TRACE|DEBUG|INFO|LOG|WARN|ERROR|FATAL|OFF`

--- a/src/lib/custom-logger.service.ts
+++ b/src/lib/custom-logger.service.ts
@@ -1,4 +1,5 @@
 import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
+import { DatePipe } from '@angular/common';
 
 import {LoggerConfig} from './logger.config';
 import {NGXLoggerHttpService} from './http.service';
@@ -15,14 +16,14 @@ export class CustomNGXLoggerService {
 
   constructor(private readonly mapperService: NGXMapperService,
               private readonly httpService: NGXLoggerHttpService,
-              @Inject(PLATFORM_ID) private readonly platformId) {
+              @Inject(PLATFORM_ID) private readonly platformId, private readonly datePipe: DatePipe) {
   }
 
   create(config: LoggerConfig, httpService?: NGXLoggerHttpService, logMonitor?: NGXLoggerMonitor,
          mapperService?: NGXMapperService): NGXLogger {
     // you can inject your own httpService or use the default,
     const logger = new NGXLogger(mapperService || this.mapperService,
-      httpService || this.httpService, config, this.platformId);
+      httpService || this.httpService, config, this.platformId, this.datePipe);
 
     if (logMonitor) {
       logger.registerMonitor(logMonitor);

--- a/src/lib/logger.config.ts
+++ b/src/lib/logger.config.ts
@@ -7,4 +7,8 @@ export class LoggerConfig {
   disableConsoleLogging?: boolean;
   httpResponseType?: 'arraybuffer' | 'blob' | 'text' | 'json';
   enableSourceMaps?: boolean;
+  /** Timestamp format. Defaults to ISOString */
+  timestampFormat?: 'short' | 'medium' | 'long' | 'full' | 'shortDate' |
+    'mediumDate' | 'longDate' | 'fullDate' | 'shortTime' | 'mediumTime' |
+    'longTime' | 'fullTime' ;
 }

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -1,6 +1,6 @@
 import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, DatePipe } from '@angular/common';
 
 import { NGXLoggerHttpService } from './http.service';
 import {LogPosition} from './types/log-position';
@@ -36,7 +36,8 @@ export class NGXLogger {
   private _loggerMonitor: NGXLoggerMonitor;
 
   constructor(private readonly mapperService: NGXMapperService, private readonly httpService: NGXLoggerHttpService,
-              loggerConfig: LoggerConfig, @Inject(PLATFORM_ID) private platformId) {
+              loggerConfig: LoggerConfig, @Inject(PLATFORM_ID) private platformId,
+              private datePipe: DatePipe) {
     this._isIE = isPlatformBrowser(platformId) && navigator && navigator.userAgent &&
       !!(navigator.userAgent.indexOf('MSIE') !== -1 || navigator.userAgent.match(/Trident\//) || navigator.userAgent.match(/Edge\//));
 
@@ -171,7 +172,9 @@ export class NGXLogger {
     // only use validated parameters for HTTP requests
     const validatedAdditionalParameters = NGXLoggerUtils.prepareAdditionalParameters(additional);
 
-    const timestamp = new Date().toISOString();
+    const timestamp = config.timestampFormat ?
+     this.datePipe.transform(new Date(), config.timestampFormat) :
+     new Date().toISOString();
 
     // const callerDetails = NGXLoggerUtils.getCallerDetails();
     this.mapperService.getCallerDetails(config.enableSourceMaps).subscribe((callerDetails: LogPosition) => {

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -37,7 +37,7 @@ export class NGXLogger {
 
   constructor(private readonly mapperService: NGXMapperService, private readonly httpService: NGXLoggerHttpService,
               loggerConfig: LoggerConfig, @Inject(PLATFORM_ID) private platformId,
-              private datePipe: DatePipe) {
+              private readonly datePipe: DatePipe) {
     this._isIE = isPlatformBrowser(platformId) && navigator && navigator.userAgent &&
       !!(navigator.userAgent.indexOf('MSIE') !== -1 || navigator.userAgent.match(/Trident\//) || navigator.userAgent.match(/Edge\//));
 


### PR DESCRIPTION
Following up on #96 and #159 , implemented a simple solution to give a custom timestamp format to the config object.

It uses classic DatePipe formats https://angular.io/api/common/DatePipe#pre-defined-format-options as discussed.