### PR TITLE
Authorize custom timestamps formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] - Merged features waiting to be published in upcoming version
+
+- None at the time.
+
+## [4.1.5] - 2020-04-16
+
+### Fixed
+
+- Now support custom format timestamps in addition to pre-defined ones in Angular [@qortex](https://github.com/qortex). Fixes #178.

--- a/README.MD
+++ b/README.MD
@@ -145,9 +145,8 @@ export class YourComponent {
 - serverLoggingUrl {string}: URL to POST logs.
 - httpResponseType {'arraybuffer' | 'blob' | 'text' | 'json'}: the response type of the HTTP Logging request.
 - enableSourceMaps {boolean}: enables manual parsing of Source Maps
-   - Note: In order for the enableSourceMaps flag to work, your app must generate the source maps during the build process. If your using AngularCli you can generate Source Maps by setting **"sourceMap": {"scripts": true}** (or for older version of angularCli **"sourceMap": true**) in your angular.json
-- timestampFormat {'short' | 'medium' | 'long' | 'full' | 'shortDate' | 'mediumDate' | 'longDate' | 'fullDate' | 'shortTime' | 'mediumTime' | 'longTime' | 'fullTime'}: format for the timestamp displayed with each log message. Can be any of the classic formatting options from the Angular [DatePipe](https://angular.io/api/common/DatePipe#pre-defined-format-options).
-
+  - Note: In order for the enableSourceMaps flag to work, your app must generate the source maps during the build process. If your using AngularCli you can generate Source Maps by setting **"sourceMap": {"scripts": true}** (or for older version of angularCli **"sourceMap": true**) in your angular.json
+- timestampFormat {string}: format for the timestamp displayed with each log message. Can be any of the formatting options accepted by the classic Angular [DatePipe](https://angular.io/api/common/DatePipe#pre-defined-format-options).
 
 NgxLoggerLevels: `TRACE|DEBUG|INFO|LOG|WARN|ERROR|FATAL|OFF`
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "4.1.4",
+  "version": "4.1.5",
   "license": "MIT",
   "scripts": {
     "ng": "ng",
@@ -32,7 +32,8 @@
     "yildiraymeric",
     "th3n3wguy <tarleton.shane@gmail.com>",
     "bniedermeyer",
-    "jbarrett732"
+    "jbarrett732",
+    "qortex"
   ],
   "keywords": [
     "angular",

--- a/src/lib/logger.config.ts
+++ b/src/lib/logger.config.ts
@@ -7,8 +7,6 @@ export class LoggerConfig {
   disableConsoleLogging?: boolean;
   httpResponseType?: 'arraybuffer' | 'blob' | 'text' | 'json';
   enableSourceMaps?: boolean;
-  /** Timestamp format. Defaults to ISOString */
-  timestampFormat?: 'short' | 'medium' | 'long' | 'full' | 'shortDate' |
-    'mediumDate' | 'longDate' | 'fullDate' | 'shortTime' | 'mediumTime' |
-    'longTime' | 'fullTime' ;
+  /** Timestamp format: any format accepted by Angular DatePipe. Defaults to ISOString */
+  timestampFormat?: string;
 }


### PR DESCRIPTION
Fixes #178 

The timestamp formats were wrongly restricted to explicitly defined ones in Angular `DatePipe`. It is also possible to build specific timestamp formats.

As a result the type for the specification should be `string` and not restricted to built-in format names.