### PR TITLE
Change Trace log color from Blue to Purple for readability on Dark Theme #188

### DIFF
--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -17,7 +17,9 @@ export class AppComponent {
    * @param newLevel
    */
   handleLogLevelChange(newLevel: NgxLoggerLevel) {
-    this.logger.updateConfig({level: newLevel});
+    const updatedConfig = this.logger.getConfigSnapshot();
+    updatedConfig.level = newLevel;
+    this.logger.updateConfig(updatedConfig);
   }
 
   /**

--- a/projects/demo/src/app/app.module.ts
+++ b/projects/demo/src/app/app.module.ts
@@ -16,7 +16,7 @@ import { LoggerModule, NgxLoggerLevel } from 'ngx-logger';
 import { AppComponent } from './app.component';
 import { LogConfigComponent } from './log-config/log-config.component';
 import { LoggerFormComponent } from './logger-form/logger-form.component';
-import { HttpClientModule } from "@angular/common/http";
+import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
   declarations: [AppComponent, LogConfigComponent, LoggerFormComponent],
@@ -25,7 +25,9 @@ import { HttpClientModule } from "@angular/common/http";
     HttpClientModule,
     BrowserAnimationsModule,
     ReactiveFormsModule,
-    LoggerModule.forRoot({ level: NgxLoggerLevel.DEBUG }),
+    LoggerModule.forRoot({
+      level: NgxLoggerLevel.DEBUG
+    }),
     MatButtonModule,
     MatCardModule,
     MatChipsModule,
@@ -37,4 +39,4 @@ import { HttpClientModule } from "@angular/common/http";
   providers: [],
   bootstrap: [AppComponent]
 })
-export class AppModule {}
+export class AppModule { }

--- a/src/lib/config.engine.ts
+++ b/src/lib/config.engine.ts
@@ -15,7 +15,6 @@ export class NGXLoggerConfigEngine {
     return this._clone(this._config);
   }
 
-
   // TODO: add tests around cloning the config. updating an object passed into the config (or retrieving from the config)
   // should not update the active config, this is a shallow clone. If our config ever becomes hierarchical we must make
   // this a deep clone

--- a/src/lib/logger.config.ts
+++ b/src/lib/logger.config.ts
@@ -11,4 +11,5 @@ export class LoggerConfig {
   timestampFormat?: 'short' | 'medium' | 'long' | 'full' | 'shortDate' |
     'mediumDate' | 'longDate' | 'fullDate' | 'shortTime' | 'mediumTime' |
     'longTime' | 'fullTime' ;
+  customColorScheme?: Array<string>;
 }

--- a/src/lib/logger.service.spec.ts
+++ b/src/lib/logger.service.spec.ts
@@ -46,8 +46,6 @@ describe('NGXLogger', () => {
     it('should call _log with trace', inject(
       [NGXLogger],
       (logger: NGXLogger) => {
-
-
         const logSpy = spyOn(<any>logger, '_log');
 
         logger.trace('message');
@@ -61,8 +59,6 @@ describe('NGXLogger', () => {
     it('should call _log with debug', inject(
       [NGXLogger],
       (logger: NGXLogger) => {
-
-
         const logSpy = spyOn(<any>logger, '_log');
 
         logger.debug('message');
@@ -76,8 +72,6 @@ describe('NGXLogger', () => {
     it('should call _log with info', inject(
       [NGXLogger],
       (logger: NGXLogger) => {
-
-
         const logSpy = spyOn(<any>logger, '_log');
 
         logger.info('message');
@@ -91,8 +85,6 @@ describe('NGXLogger', () => {
     it('should call _log with log', inject(
       [NGXLogger],
       (logger: NGXLogger) => {
-
-
         const logSpy = spyOn(<any>logger, '_log');
 
         logger.log('message');
@@ -106,8 +98,6 @@ describe('NGXLogger', () => {
     it('should call _log with warn', inject(
       [NGXLogger],
       (logger: NGXLogger) => {
-
-
         const logSpy = spyOn(<any>logger, '_log');
 
         logger.warn('message');
@@ -121,8 +111,6 @@ describe('NGXLogger', () => {
     it('should call _log with error', inject(
       [NGXLogger],
       (logger: NGXLogger) => {
-
-
         const logSpy = spyOn(<any>logger, '_log');
 
         logger.error('message');
@@ -136,8 +124,6 @@ describe('NGXLogger', () => {
     it('should call _log with fatal', inject(
       [NGXLogger],
       (logger: NGXLogger) => {
-
-
         const logSpy = spyOn(<any>logger, '_log');
 
         logger.fatal('message');

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -3,7 +3,7 @@ import { HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http
 import { isPlatformBrowser, DatePipe } from '@angular/common';
 
 import { NGXLoggerHttpService } from './http.service';
-import {LogPosition} from './types/log-position';
+import { LogPosition } from './types/log-position';
 import { NgxLoggerLevel } from './types/logger-level.enum';
 import { LoggerConfig } from './logger.config';
 import { NGXLoggerConfigEngine } from './config.engine';
@@ -36,8 +36,8 @@ export class NGXLogger {
   private _loggerMonitor: NGXLoggerMonitor;
 
   constructor(private readonly mapperService: NGXMapperService, private readonly httpService: NGXLoggerHttpService,
-              loggerConfig: LoggerConfig, @Inject(PLATFORM_ID) private platformId,
-              private readonly datePipe: DatePipe) {
+    loggerConfig: LoggerConfig, @Inject(PLATFORM_ID) private platformId,
+    private readonly datePipe: DatePipe) {
     this._isIE = isPlatformBrowser(platformId) && navigator && navigator.userAgent &&
       !!(navigator.userAgent.indexOf('MSIE') !== -1 || navigator.userAgent.match(/Trident\//) || navigator.userAgent.match(/Edge\//));
 
@@ -123,8 +123,8 @@ export class NGXLogger {
   }
 
   private _logModern(level: NgxLoggerLevel, metaString: string, message: string, additional: any[]): void {
-
-    const color = NGXLoggerUtils.getColor(level);
+    const configuredColors = this.getConfigSnapshot().customColorScheme;
+    const color = NGXLoggerUtils.getColor(level, configuredColors);
 
     // make sure additional isn't null or undefined so that ...additional doesn't error
     additional = additional || [];
@@ -173,8 +173,8 @@ export class NGXLogger {
     const validatedAdditionalParameters = NGXLoggerUtils.prepareAdditionalParameters(additional);
 
     const timestamp = config.timestampFormat ?
-     this.datePipe.transform(new Date(), config.timestampFormat) :
-     new Date().toISOString();
+      this.datePipe.transform(new Date(), config.timestampFormat) :
+      new Date().toISOString();
 
     // const callerDetails = NGXLoggerUtils.getCallerDetails();
     this.mapperService.getCallerDetails(config.enableSourceMaps).subscribe((callerDetails: LogPosition) => {
@@ -207,8 +207,8 @@ export class NGXLogger {
         };
         // Allow logging on server even if client log level is off
         this.httpService.logOnServer(config.serverLoggingUrl, logObject, options).subscribe((res: any) => {
-            // I don't think we should do anything on success
-          },
+          // I don't think we should do anything on success
+        },
           (error: HttpErrorResponse) => {
             this._log(NgxLoggerLevel.ERROR, `FAILED TO LOG ON SERVER: ${message}`, [error], false);
           }

--- a/src/lib/types/logger-level.enum.ts
+++ b/src/lib/types/logger-level.enum.ts
@@ -1,10 +1,10 @@
 export enum NgxLoggerLevel {
   TRACE = 0,
-  DEBUG,
-  INFO,
-  LOG,
-  WARN,
-  ERROR,
-  FATAL,
-  OFF
+  DEBUG = 1,
+  INFO = 2,
+  LOG = 3,
+  WARN = 4,
+  ERROR = 5,
+  FATAL = 6,
+  OFF = 7
 }

--- a/src/lib/utils/logger.utils.spec.ts
+++ b/src/lib/utils/logger.utils.spec.ts
@@ -22,8 +22,14 @@ describe('NGXLoggerUtils', () => {
 
       const color = NGXLoggerUtils.getColor(NgxLoggerLevel.DEBUG, config.customColorScheme);
 
-      expect(color).toBe('#008080');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.TRACE, config.customColorScheme)).toBe('#800080');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.DEBUG, config.customColorScheme)).toBe('#008080');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.INFO, config.customColorScheme)).toBe('#808080');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.LOG, config.customColorScheme)).toBe('#808080');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.WARN, config.customColorScheme)).toBe('#FF0000');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.ERROR, config.customColorScheme)).toBe('#FF0000');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.FATAL, config.customColorScheme)).toBe('#FF0000');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.OFF, config.customColorScheme)).toBeUndefined();
     });
   });
-
 });

--- a/src/lib/utils/logger.utils.spec.ts
+++ b/src/lib/utils/logger.utils.spec.ts
@@ -1,0 +1,29 @@
+import { LoggerConfig } from './../logger.config';
+import { NGXLoggerUtils } from './logger.utils';
+
+import { NgxLoggerLevel } from '../types/logger-level.enum';
+
+describe('NGXLoggerUtils', () => {
+  describe('getColor', () => {
+    it('should return default values if config is not provided', () => {
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.TRACE)).toBe('purple');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.DEBUG)).toBe('teal');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.INFO)).toBe('gray');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.LOG)).toBe('gray');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.WARN)).toBe('red');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.ERROR)).toBe('red');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.FATAL)).toBe('red');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.OFF)).toBeUndefined();
+    });
+
+    it('should return custom values if config is provided', () => {
+      const config = new LoggerConfig();
+      config.customColorScheme = ['#800080', '#008080', '#808080', '#808080', '#FF0000', '#FF0000', '#FF0000'];
+
+      const color = NGXLoggerUtils.getColor(NgxLoggerLevel.DEBUG, config.customColorScheme);
+
+      expect(color).toBe('#008080');
+    });
+  });
+
+});

--- a/src/lib/utils/logger.utils.ts
+++ b/src/lib/utils/logger.utils.ts
@@ -1,4 +1,4 @@
-import {NgxLoggerLevel} from '../types/logger-level.enum';
+import { NgxLoggerLevel } from '../types/logger-level.enum';
 
 export class NGXLoggerUtils {
 
@@ -8,25 +8,34 @@ export class NGXLoggerUtils {
     return `${timestamp} ${logLevel}${fileDetails}`;
   }
 
-  static getColor(level: NgxLoggerLevel): 'purple' | 'teal' | 'gray' | 'red' | undefined {
+  static getColor(level: NgxLoggerLevel, config?: Array<string>): string | undefined {
     switch (level) {
       case NgxLoggerLevel.TRACE:
-        return 'purple';
+        return this.getColorFromConfig(NgxLoggerLevel.TRACE, 'purple', config);
       case NgxLoggerLevel.DEBUG:
-        return 'teal';
+        return this.getColorFromConfig(NgxLoggerLevel.DEBUG, 'teal', config);
       case NgxLoggerLevel.INFO:
+        return this.getColorFromConfig(NgxLoggerLevel.INFO, 'gray', config);
       case NgxLoggerLevel.LOG:
-        return 'gray';
+        return this.getColorFromConfig(NgxLoggerLevel.INFO, 'gray', config);
       case NgxLoggerLevel.WARN:
+        return this.getColorFromConfig(NgxLoggerLevel.FATAL, 'red', config);
       case NgxLoggerLevel.ERROR:
+        return this.getColorFromConfig(NgxLoggerLevel.FATAL, 'red', config);
       case NgxLoggerLevel.FATAL:
-        return 'red';
+        return this.getColorFromConfig(NgxLoggerLevel.FATAL, 'red', config);
       case NgxLoggerLevel.OFF:
       default:
         return;
     }
   }
 
+  private static getColorFromConfig(level: number, defaultValue: string, config: Array<string>): string | undefined {
+    if (!config) {
+      return defaultValue;
+    }
+    return config[level];
+  }
 
   /**
    *  This allows us to see who called the logger

--- a/src/lib/utils/logger.utils.ts
+++ b/src/lib/utils/logger.utils.ts
@@ -8,10 +8,10 @@ export class NGXLoggerUtils {
     return `${timestamp} ${logLevel}${fileDetails}`;
   }
 
-  static getColor(level: NgxLoggerLevel): 'blue' | 'teal' | 'gray' | 'red' | undefined {
+  static getColor(level: NgxLoggerLevel): 'purple' | 'teal' | 'gray' | 'red' | undefined {
     switch (level) {
       case NgxLoggerLevel.TRACE:
-        return 'blue';
+        return 'purple';
       case NgxLoggerLevel.DEBUG:
         return 'teal';
       case NgxLoggerLevel.INFO:


### PR DESCRIPTION
As per #188, here's the PR to change the `Trace` log color for the timestamp so it gets more readable when using the dark theme in DevTools. I went with purple instead of blue. This color proves to be readable either in light or dark theme.

Here's a preview of it :

After :
![image](https://user-images.githubusercontent.com/2490360/79224537-3e2b3780-7e29-11ea-82bb-1345c47ba28a.png)

Before :
![image](https://user-images.githubusercontent.com/2490360/79224619-6a46b880-7e29-11ea-8144-37a536498cac.png)

As well as what it looks like on Light Theme with purple :
![image](https://user-images.githubusercontent.com/2490360/79224722-9bbf8400-7e29-11ea-8152-673c45acea9a.png)

Thanks for your time!