### PR TITLE
Feature/proxied caller config

### DIFF
--- a/src/lib/logger.config.ts
+++ b/src/lib/logger.config.ts
@@ -8,6 +8,7 @@ export class LoggerConfig {
   disableConsoleLogging?: boolean;
   httpResponseType?: 'arraybuffer' | 'blob' | 'text' | 'json';
   enableSourceMaps?: boolean;
+  proxiedCaller?: boolean;
   /** Timestamp format: any format accepted by Angular DatePipe. Defaults to ISOString */
   timestampFormat?: string;
   colorScheme?: LoggerColorScheme;

--- a/src/lib/logger.config.ts
+++ b/src/lib/logger.config.ts
@@ -8,7 +8,10 @@ export class LoggerConfig {
   disableConsoleLogging?: boolean;
   httpResponseType?: 'arraybuffer' | 'blob' | 'text' | 'json';
   enableSourceMaps?: boolean;
-  proxiedCaller?: boolean;
+  /** Number of calls that will be ignored when trying to get line of stacktrace
+   * The base number is 5. The result number is 5 + proxiedSteps
+  */
+ proxiedSteps?: number;
   /** Timestamp format: any format accepted by Angular DatePipe. Defaults to ISOString */
   timestampFormat?: string;
   colorScheme?: LoggerColorScheme;

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -177,7 +177,7 @@ export class NGXLogger {
       new Date().toISOString();
 
     // const callerDetails = NGXLoggerUtils.getCallerDetails();
-    this.mapperService.getCallerDetails(config.enableSourceMaps, config.proxiedCaller).subscribe((callerDetails: LogPosition) => {
+    this.mapperService.getCallerDetails(config.enableSourceMaps, config.proxiedSteps).subscribe((callerDetails: LogPosition) => {
       const logObject: NGXLogInterface = {
         message: message,
         additional: validatedAdditionalParameters,

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -177,7 +177,7 @@ export class NGXLogger {
       new Date().toISOString();
 
     // const callerDetails = NGXLoggerUtils.getCallerDetails();
-    this.mapperService.getCallerDetails(config.enableSourceMaps).subscribe((callerDetails: LogPosition) => {
+    this.mapperService.getCallerDetails(config.enableSourceMaps, config.proxiedCaller).subscribe((callerDetails: LogPosition) => {
       const logObject: NGXLogInterface = {
         message: message,
         additional: validatedAdditionalParameters,

--- a/src/lib/mapper.service.ts
+++ b/src/lib/mapper.service.ts
@@ -21,7 +21,7 @@ export class NGXMapperService {
   /*
   Static Functions
  */
-  private static getStackLine(): string {
+  private static getStackLine(proxiedCaller: boolean): string {
     const error = new Error();
 
     try {
@@ -30,7 +30,7 @@ export class NGXMapperService {
     } catch (e) {
 
       try {
-        return error.stack.split('\n')[5];
+        return error.stack.split('\n')[(proxiedCaller ? 6 : 5)];
       } catch (e) {
         return null;
       }
@@ -167,10 +167,10 @@ export class NGXMapperService {
    * and number of the call
    * @param sourceMapsEnabled
    */
-  public getCallerDetails(sourceMapsEnabled: boolean): Observable<LogPosition> {
+  public getCallerDetails(sourceMapsEnabled: boolean, proxiedCaller: boolean): Observable<LogPosition> {
     // parse generated file mapping from stack trace
 
-    const stackLine = NGXMapperService.getStackLine();
+    const stackLine = NGXMapperService.getStackLine(proxiedCaller);
 
     // if we were not able to parse the stackLine, just return an empty Log Position
     if (!stackLine) {

--- a/src/lib/mapper.service.ts
+++ b/src/lib/mapper.service.ts
@@ -21,7 +21,7 @@ export class NGXMapperService {
   /*
   Static Functions
  */
-  private static getStackLine(proxiedCaller: boolean): string {
+  private static getStackLine(proxiedSteps: number): string {
     const error = new Error();
 
     try {
@@ -30,7 +30,7 @@ export class NGXMapperService {
     } catch (e) {
 
       try {
-        return error.stack.split('\n')[(proxiedCaller ? 6 : 5)];
+        return error.stack.split('\n')[(5 + (proxiedSteps || 0))];
       } catch (e) {
         return null;
       }
@@ -166,11 +166,12 @@ export class NGXMapperService {
    * If sourceMaps are enabled, it attemps to get the source map from the server, and use that to parse the file name
    * and number of the call
    * @param sourceMapsEnabled
+   * @param proxiedSteps
    */
-  public getCallerDetails(sourceMapsEnabled: boolean, proxiedCaller: boolean): Observable<LogPosition> {
+  public getCallerDetails(sourceMapsEnabled: boolean, proxiedSteps: number): Observable<LogPosition> {
     // parse generated file mapping from stack trace
 
-    const stackLine = NGXMapperService.getStackLine(proxiedCaller);
+    const stackLine = NGXMapperService.getStackLine(proxiedSteps);
 
     // if we were not able to parse the stackLine, just return an empty Log Position
     if (!stackLine) {


### PR DESCRIPTION
I have added configuration option called **proxiedCaller**, if this option is set to true then the caller information is resolved with an offset of +1. 

This is useful when using an abstraction over the `NGXLogger` such as a custom `LoggerService`, that uses an injected `NGXLogger`. In this scenario the caller information would always point to the `LoggerService` file, which is not very useful. With **proxiedCaller: true** configuration the caller information will be resolved to that which is calling the `LoggerService` and not the `NGXLogger`.

**Default value of `undefined` does not change the current behavior, user must opt-in with a value of `true` to enable the new behavior.**