### PR TITLE
Feature : option to disable the file details

### DIFF
--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -2,5 +2,5 @@
 <div class="controls">
   <h3>Please open your console to see the output of the demo</h3>
   <app-logger (logToConsole)="handleLog($event)"></app-logger>
-  <app-log-config (loggerLevelChange)="handleLogLevelChange($event)"></app-log-config>
+  <app-log-config (loggerLevelChange)="handleLogLevelChange($event)" (disableFileDetails)="handleDisableFileDetails($event)"></app-log-config>
 </div>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -51,4 +51,10 @@ export class AppComponent {
         break;
     }
   }
+
+  handleDisableFileDetails(disableFileDetails: boolean) {
+    const updatedConfig = this.logger.getConfigSnapshot();
+    updatedConfig.disableFileDetails = disableFileDetails;
+    this.logger.updateConfig(updatedConfig);
+  }
 }

--- a/projects/demo/src/app/app.module.ts
+++ b/projects/demo/src/app/app.module.ts
@@ -9,7 +9,9 @@ import {
   MatFormFieldModule,
   MatInputModule,
   MatToolbarModule,
-  MatSelectModule
+  MatSelectModule,
+  MatSlideToggleModule,
+  MatTooltipModule,
 } from '@angular/material';
 import { LoggerModule, NgxLoggerLevel } from 'ngx-logger';
 
@@ -26,7 +28,7 @@ import { HttpClientModule } from '@angular/common/http';
     BrowserAnimationsModule,
     ReactiveFormsModule,
     LoggerModule.forRoot({
-      level: NgxLoggerLevel.DEBUG
+      level: NgxLoggerLevel.DEBUG,
     }),
     MatButtonModule,
     MatCardModule,
@@ -34,7 +36,9 @@ import { HttpClientModule } from '@angular/common/http';
     MatFormFieldModule,
     MatInputModule,
     MatToolbarModule,
-    MatSelectModule
+    MatSelectModule,
+    MatSlideToggleModule,
+    MatTooltipModule,
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/projects/demo/src/app/log-config/log-config.component.html
+++ b/projects/demo/src/app/log-config/log-config.component.html
@@ -29,5 +29,10 @@
     <div class="button-row">
       <button mat-stroked-button (click)="handleButtonClick(NgxLoggerLevel.OFF)">Off (Nothing will be logged)</button>
     </div>
+
+    <hr/>
+
+    <mat-slide-toggle (change)="disableFileDetailsChange($event)" color="primary" matTooltip="The file name and line won't be logged">Disable file details</mat-slide-toggle>
+
   </mat-card-content>
 </mat-card>

--- a/projects/demo/src/app/log-config/log-config.component.ts
+++ b/projects/demo/src/app/log-config/log-config.component.ts
@@ -1,4 +1,5 @@
 import {Component, Output, EventEmitter} from '@angular/core';
+import { MatSlideToggleChange } from '@angular/material';
 import {NgxLoggerLevel} from 'ngx-logger';
 
 @Component({
@@ -15,6 +16,9 @@ export class LogConfigComponent {
   private currentLogLevel: NgxLoggerLevel = NgxLoggerLevel.DEBUG;
 
   NgxLoggerLevel = NgxLoggerLevel;
+
+  @Output()
+  disableFileDetails: EventEmitter<boolean> = new EventEmitter<boolean>();
 
   /**
    * Get the chip color based on the current logger level configuration
@@ -47,5 +51,9 @@ export class LogConfigComponent {
     this.currentLogLevel = newLevel;
 
     this.loggerLevelChange.emit(this.currentLogLevel);
+  }
+
+  disableFileDetailsChange(change: MatSlideToggleChange) {
+    this.disableFileDetails.emit(change.checked);
   }
 }

--- a/src/lib/logger.config.ts
+++ b/src/lib/logger.config.ts
@@ -11,4 +11,5 @@ export class LoggerConfig {
   /** Timestamp format: any format accepted by Angular DatePipe. Defaults to ISOString */
   timestampFormat?: string;
   colorScheme?: LoggerColorScheme;
+  disableFileDetails?: boolean;
 }

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -218,8 +218,12 @@ export class NGXLogger {
 
       // if no message or the log level is less than the environ
       if (isLogLevelEnabled && !config.disableConsoleLogging) {
-        const metaString = NGXLoggerUtils.prepareMetaString(timestamp, logLevelString,
-          callerDetails.fileName, callerDetails.lineNumber.toString());
+        const metaString = NGXLoggerUtils.prepareMetaString(
+          timestamp,
+          logLevelString,
+          config.disableFileDetails ? null : callerDetails.fileName,
+          callerDetails.lineNumber.toString()
+        );
 
         return this._logFunc(level, metaString, message, additional);
       }


### PR DESCRIPTION
I was starting to use this module and I was frustrated to not be able to disable the file details because I really don't need it.
I've found a feature request : #174 !

Here the PR where I add an option `disableFileDetails` in the module configuration to allow to disable the file details in the log message.
The default behavior still the same but when this option is set to true, the file details won't be logged.
I've updated the demo to test this option.

The trick is to play with the arguments of the method `NGXLoggerUtils.prepareMetaString` by sending `fileName = null` so the internal check won't log the file details ;)

