### PR TITLE
Fix #213 : use console.debug for DEBUG level

### DIFF
--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -146,10 +146,9 @@ export class NGXLogger {
       //   console.trace(`%c${metaString}`, `color:${color}`, message, ...additional);
       //   break;
 
-      //  Disabling console.debug, because Has this hidden by default.
-      // case NgxLoggerLevel.DEBUG:
-      //   console.debug(`%c${metaString}`, `color:${color}`, message, ...additional);
-      //   break;
+      case NgxLoggerLevel.DEBUG:
+        console.debug(`%c${metaString}`, `color:${color}`, message, ...additional);
+        break;
       default:
         console.log(`%c${metaString}`, `color:${color}`, message, ...additional);
     }


### PR DESCRIPTION
It is true that Chrome (tested on version 88.0.4324.150) hides it by default but it is not a reason to use "log" for DEBUG level

The levels have purpose  and features around them, using console.debug for DEBUG level is normal