### PR TITLE
Fixes #227 enableSourceMaps is not working in firefox

### DIFF
--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -185,7 +185,6 @@ export class NGXLogger {
       this.datePipe.transform(new Date(), config.timestampFormat) :
       new Date().toISOString();
 
-    // const callerDetails = NGXLoggerUtils.getCallerDetails();
     this.mapperService.getCallerDetails(config.enableSourceMaps, config.proxiedSteps).subscribe((callerDetails: LogPosition) => {
       const logObject: NGXLogInterface = {
         message: message,

--- a/src/lib/mapper.service.ts
+++ b/src/lib/mapper.service.ts
@@ -51,7 +51,7 @@ export class NGXMapperService {
         const firstStackLine = error.stack.split('\n')[0];
         if (!firstStackLine.includes('.js:')) {
           // The stacktrace starts with no function call (example in Chrome or Edge)
-          defaultProxy = 5;
+          defaultProxy = defaultProxy + 1;
         }
 
         return error.stack.split('\n')[(defaultProxy + (proxiedSteps || 0))];

--- a/src/lib/mapper.service.ts
+++ b/src/lib/mapper.service.ts
@@ -1,10 +1,10 @@
-import {SourceMap} from '@angular/compiler';
-import {Injectable} from '@angular/core';
-import {HttpBackend, HttpRequest, HttpResponse} from '@angular/common/http';
+import { SourceMap } from '@angular/compiler';
+import { Injectable } from '@angular/core';
+import { HttpBackend, HttpRequest, HttpResponse } from '@angular/common/http';
 import * as vlq from 'vlq';
-import {Observable, of} from 'rxjs';
-import {catchError, filter, map, retry, shareReplay, switchMap} from 'rxjs/operators';
-import {LogPosition} from './types/log-position';
+import { Observable, of } from 'rxjs';
+import { catchError, filter, map, retry, shareReplay, switchMap } from 'rxjs/operators';
+import { LogPosition } from './types/log-position';
 
 @Injectable()
 export class NGXMapperService {
@@ -30,7 +30,31 @@ export class NGXMapperService {
     } catch (e) {
 
       try {
-        return error.stack.split('\n')[(5 + (proxiedSteps || 0))];
+        // Here are different examples of stacktrace 
+
+        // Firefox (last line is the user code, the 4 first are ours):
+        // getStackLine@http://localhost:4200/main.js:358:23
+        // getCallerDetails@http://localhost:4200/main.js:557:44
+        // _log@http://localhost:4200/main.js:830:28
+        // debug@http://localhost:4200/main.js:652:14
+        // handleLog@http://localhost:4200/main.js:1158:29
+
+        // Chrome and Edge (last line is the user code):
+        // Error
+        // at Function.getStackLine (ngx-logger.js:329)
+        // at NGXMapperService.getCallerDetails (ngx-logger.js:528)
+        // at NGXLogger._log (ngx-logger.js:801)
+        // at NGXLogger.info (ngx-logger.js:631)
+        // at AppComponent.handleLog (app.component.ts:38)
+
+        let defaultProxy = 4; // We make 4 functions call before getting here
+        const firstStackLine = error.stack.split('\n')[0];
+        if (!firstStackLine.includes('.js:')) {
+          // The stacktrace starts with no function call (example in Chrome or Edge)
+          defaultProxy = 5;
+        }
+
+        return error.stack.split('\n')[(defaultProxy + (proxiedSteps || 0))];
       } catch (e) {
         return null;
       }
@@ -54,9 +78,15 @@ export class NGXMapperService {
   }
 
   private static getTranspileLocation(stackLine: string): string {
+    // Example stackLine:
+    // Firefox : getStackLine@http://localhost:4200/main.js:358:23
+    // Chrome and Edge : at Function.getStackLine (ngx-logger.js:329)
     let locationStartIndex = stackLine.indexOf('(');
     if (locationStartIndex < 0) {
-      locationStartIndex = stackLine.lastIndexOf(' ');
+      locationStartIndex = stackLine.lastIndexOf('@');
+      if (locationStartIndex < 0) {
+        locationStartIndex = stackLine.lastIndexOf(' ');
+      }
     }
 
     let locationEndIndex = stackLine.indexOf(')');

--- a/src/lib/utils/logger.utils.ts
+++ b/src/lib/utils/logger.utils.ts
@@ -39,32 +39,6 @@ export class NGXLoggerUtils {
     return configColorScheme[level];
   }
 
-  /**
-   *  This allows us to see who called the logger
-   */
-  static getCallerDetails(): { lineNumber: string, fileName: string } {
-    const err = (new Error(''));
-
-    try {
-      // this should produce the line which NGX Logger was called
-      const callerLine = err.stack.split('\n')[4].split('/');
-
-      // returns the file:lineNumber
-      const fileLineNumber = callerLine[callerLine.length - 1].replace(/[)]/g, '').split(':');
-
-      return {
-        fileName: fileLineNumber[0],
-        lineNumber: fileLineNumber[1]
-      };
-    } catch (e) {
-      return {
-        fileName: null,
-        lineNumber: null
-      };
-    }
-
-  }
-
   static prepareMessage(message) {
     try {
       if (typeof message !== 'string' && !(message instanceof Error)) {


### PR DESCRIPTION
Actually it fixes the stackLine parsing when using firefox

This fixes the sourceMap location and the LogPostion