### PR TITLE
add columnNumber to logObject

### DIFF
--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -194,7 +194,8 @@ export class NGXLogger {
         level: level,
         timestamp: timestamp,
         fileName: callerDetails.fileName,
-        lineNumber: callerDetails.lineNumber.toString()
+        lineNumber: callerDetails.lineNumber.toString(),
+        columnNumber: callerDetails.columnNumber.toString()
       };
 
       if (this._loggerMonitor && isLogLevelEnabled) {


### PR DESCRIPTION
To be able to trace errors logged to the server in production, without using sourcemaps on client side. Add the column number to object pushed to the backend.