### PR TITLE
Fix get color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Merged features waiting to be published in upcoming version
 
+- Fix getcolor, colorscheme was not binded correctly [#253](https://github.com/dbfannin/ngx-logger/pull/253). Thanks [@jschank](https://github.com/jschank)
+
+
 ## [4.2.1] - 2021-02-23
 
 ### Fixed

--- a/src/lib/utils/logger.utils.spec.ts
+++ b/src/lib/utils/logger.utils.spec.ts
@@ -18,15 +18,15 @@ describe('NGXLoggerUtils', () => {
 
     it('should return custom values if config is provided', () => {
       const config = new LoggerConfig();
-      config.colorScheme = ['#800080', '#008080', '#808080', '#808080', '#FF0000', '#FF0000', '#FF0000'];
+      config.colorScheme = ['violet', 'indigo', 'blue', 'green', 'yellow', 'orange', 'red'];
 
-      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.TRACE, config.colorScheme)).toBe('#800080');
-      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.DEBUG, config.colorScheme)).toBe('#008080');
-      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.INFO, config.colorScheme)).toBe('#808080');
-      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.LOG, config.colorScheme)).toBe('#808080');
-      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.WARN, config.colorScheme)).toBe('#FF0000');
-      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.ERROR, config.colorScheme)).toBe('#FF0000');
-      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.FATAL, config.colorScheme)).toBe('#FF0000');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.TRACE, config.colorScheme)).toBe('violet');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.DEBUG, config.colorScheme)).toBe('indigo');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.INFO, config.colorScheme)).toBe('blue');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.LOG, config.colorScheme)).toBe('green');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.WARN, config.colorScheme)).toBe('yellow');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.ERROR, config.colorScheme)).toBe('orange');
+      expect(NGXLoggerUtils.getColor(NgxLoggerLevel.FATAL, config.colorScheme)).toBe('red');
       expect(NGXLoggerUtils.getColor(NgxLoggerLevel.OFF, config.colorScheme)).toBeUndefined();
     });
   });

--- a/src/lib/utils/logger.utils.ts
+++ b/src/lib/utils/logger.utils.ts
@@ -18,11 +18,11 @@ export class NGXLoggerUtils {
       case NgxLoggerLevel.INFO:
         return this.getColorFromConfig(NgxLoggerLevel.INFO, configColorScheme);
       case NgxLoggerLevel.LOG:
-        return this.getColorFromConfig(NgxLoggerLevel.INFO, configColorScheme);
+        return this.getColorFromConfig(NgxLoggerLevel.LOG, configColorScheme);
       case NgxLoggerLevel.WARN:
-        return this.getColorFromConfig(NgxLoggerLevel.FATAL, configColorScheme);
+        return this.getColorFromConfig(NgxLoggerLevel.WARN, configColorScheme);
       case NgxLoggerLevel.ERROR:
-        return this.getColorFromConfig(NgxLoggerLevel.FATAL, configColorScheme);
+        return this.getColorFromConfig(NgxLoggerLevel.ERROR, configColorScheme);
       case NgxLoggerLevel.FATAL:
         return this.getColorFromConfig(NgxLoggerLevel.FATAL, configColorScheme);
       case NgxLoggerLevel.OFF:


### PR DESCRIPTION
getColor(level, configColorScheme) was returning only TRACE, DEBUG, INFO, and FATAL. Ignoring configured colors for LOG, WARN and ERROR