### PR TITLE
Avoid dep http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Merged features waiting to be published in upcoming version
 
+## [5.0.2] - 2021-XX-XX
+
+### Changed
+- HttpClientModule is not needed by default anymore
+    If HttpClientModule is not imported and you use the ServerSide logger, it will log an error
+    If HttpClientModule is not imported and you use the enableSourceMaps, it will log an error
+
 ## [5.0.1] - 2021-11-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ NGX Logger is a simple logging module for angular (currently supports angular 6+
 npm install --save ngx-logger
 ```
 
-Once installed you need to import our main module and it's dependency on HttpClientModule:
+Once installed you need to import our main module (optionally you will need to import HttpClientModule):
 
 ```typescript
 import { LoggerModule, NgxLoggerLevel } from "ngx-logger";

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Once installed you need to import our main module and it's dependency on HttpCli
 
 ```typescript
 import { LoggerModule, NgxLoggerLevel } from "ngx-logger";
+// HttpClientModule is only needed if you want to log on server or if you want to inspect sourcemaps
 import { HttpClientModule } from "@angular/common/http";
 ```
 
@@ -28,6 +29,7 @@ The only remaining part is to list the imported module in your application modul
   declarations: [AppComponent, ...],
   imports:
   [
+    // HttpClientModule is only needed if you want to log on server or if you want to inspect sourcemaps
     HttpClientModule,
     LoggerModule.forRoot({
       serverLoggingUrl: '/api/logs',

--- a/src/lib/server/server.service.ts
+++ b/src/lib/server/server.service.ts
@@ -1,6 +1,6 @@
 import { HttpBackend, HttpHeaders, HttpParams, HttpRequest, HttpResponse } from '@angular/common/http';
-import { Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
+import { Injectable, Optional } from '@angular/core';
+import { Observable, of, throwError } from 'rxjs';
 import { catchError, filter, map } from 'rxjs/operators';
 import { INGXLoggerMetadata } from '../metadata/imetadata';
 import { INGXLoggerConfig } from '../config/iconfig';
@@ -10,7 +10,7 @@ import { INGXLoggerServerService } from './iserver.service';
 export class NGXLoggerServerService implements INGXLoggerServerService {
 
   constructor(
-    protected readonly httpBackend: HttpBackend,
+    @Optional() protected readonly httpBackend: HttpBackend,
   ) { }
 
   /**
@@ -87,6 +87,10 @@ export class NGXLoggerServerService implements INGXLoggerServerService {
     // They may log errors using this service causing circular calls
     const req = new HttpRequest<T>('POST', url, logContent, options || {});
 
+    if (!this.httpBackend) {
+      console.error('NGXLogger : Can\'t log on server because HttpBackend is not provided. You need to import HttpClientModule');
+      return of(null);
+    }
     return this.httpBackend.handle(req).pipe(
       filter(e => e instanceof HttpResponse),
       map<HttpResponse<T>, T>((httpResponse: HttpResponse<T>) => httpResponse.body)


### PR DESCRIPTION
Avoiding the mandatory dep of HttpClientModule because it is needed only for some features (serverside logging and sourcemaps parsing)

For example, users using NGXLogger in a lib do not want to import any unnecessary module