### PR TITLE
Bug 286 secure functions were not used correctly in server.service.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Merged features waiting to be published in upcoming version
 
+## [5.0.7] - 2022-01-22
+
+### Fixed
+- Now correctly secures `message` and `additional` from payload when sending log to server (fixes #286)
+
 ## [5.0.6] - 2022-01-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/lib/server/server.service.spec.ts
+++ b/src/lib/server/server.service.spec.ts
@@ -1,0 +1,79 @@
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { NgxLoggerLevel } from '../types/logger-level.enum';
+import { NGXLoggerServerService } from './server.service';
+
+describe('NGXLoggerServerService', () => {
+  let server: NGXLoggerServerService;
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        HttpClientTestingModule,
+      ],
+      providers: [
+        NGXLoggerServerService,
+      ]
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+    server = TestBed.inject(NGXLoggerServerService);
+  });
+
+  describe('sendToServer', () => {
+    it('should use customised requestbody', () => {
+      spyOn(server as any, 'customiseRequestBody').and.returnValue({
+        message: 'customised'
+      });
+
+      server.sendToServer({
+        message: 'original message',
+        level: NgxLoggerLevel.DEBUG
+      },
+        { level: NgxLoggerLevel.DEBUG },
+      );
+
+      // We want to make sure the customiseRequestBody is used
+      const req = httpMock.expectOne(req => req.body.message === 'customised');
+      expect(req).toBeTruthy();
+      httpMock.verify();
+    });
+
+    it('should use secureMessage', () => {
+      server.sendToServer({
+        message: { complexMessage: 'complex' },
+        level: NgxLoggerLevel.DEBUG
+      },
+        { level: NgxLoggerLevel.DEBUG },
+      );
+
+      // We want to make sure the message has been secured (json to string in this example)
+      const req = httpMock.expectOne(req => (typeof req.body.message) === 'string');
+      expect(req).toBeTruthy();
+      httpMock.verify();
+    });
+
+    it('should use secureAdditionalParameters', () => {
+      server.sendToServer({
+        message: 'message',
+        additional: [new Error('test')],
+        level: NgxLoggerLevel.DEBUG
+      },
+        { level: NgxLoggerLevel.DEBUG },
+      );
+
+      // We want to make sure the additional has been secured
+      const req = httpMock.expectOne(req => {
+        // Additional should be an array
+        if (!Array.isArray(req.body.additional)) {
+          return false;
+        }
+        // Checking that the error was changed into a string
+        return (typeof req.body.additional[0]) === 'string';
+      });
+      expect(req).toBeTruthy();
+      httpMock.verify();
+    });
+  })
+});

--- a/src/lib/server/server.service.ts
+++ b/src/lib/server/server.service.ts
@@ -113,10 +113,10 @@ export class NGXLoggerServerService implements INGXLoggerServerService {
 
     localMetadata.additional = this.secureAdditionalParameters(localMetadata.additional);
 
-    localMetadata.message = this.secureMessage(metadata.message);
+    localMetadata.message = this.secureMessage(localMetadata.message);
 
     // Allow users to customise the data sent to the API
-    const requestBody = this.customiseRequestBody(metadata);
+    const requestBody = this.customiseRequestBody(localMetadata);
 
     const headers = config.customHttpHeaders || new HttpHeaders();
     if (!headers.has('Content-Type')) {


### PR DESCRIPTION
`message` and `additional` are now correctly secured

Fixes #286 