### PR TITLE
Makes datepipe dependency optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - Merged features waiting to be published in upcoming version
 
+## [5.0.8] - 2022-02-20
+
+### Changed
+- Makes the DatePipe dependency Optional
+
+### Breaking Changes
+- If you use `timestampFormat`, you now need to manually provide `DatePipe` from @angular/common
+  - If not provided, this will just display an error when logging, build will not break, your application will still run and logger will still produce an output
+
 ## [5.0.7] - 2022-01-22
 
 ### Fixed

--- a/docs/config.md
+++ b/docs/config.md
@@ -13,6 +13,7 @@ Some of the options are detailed below :
 - `enableSourceMaps` {boolean}: enables manual parsing of Source Maps
   - Note: In order for the enableSourceMaps flag to work, your app must generate the source maps during the build process. If your using AngularCli you can generate Source Maps by setting `"sourceMap": {"scripts": true}` (or for older version of angularCli `"sourceMap": true`) in your angular.json
 - `timestampFormat` {string}: format for the timestamp displayed with each log message. Can be any of the formatting options accepted by the classic Angular [DatePipe](https://angular.io/api/common/DatePipe#pre-defined-format-options).
+  - Note: You need to provide DatePipe from @angular/common to use that feature
 - `colorScheme` {NGXLoggerColorScheme}: a color scheme that defines which color should be used for each log level
   - Note: the index of the scheme relates to the log level value
 - `disableFileDetails` {boolean} (defaults to false). When set to `true`, filename details will not be shown in log messages.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-logger",
-  "version": "5.0.7",
+  "version": "5.0.8",
   "license": "MIT",
   "scripts": {
     "ng": "ng",

--- a/src/lib/config/iconfig.ts
+++ b/src/lib/config/iconfig.ts
@@ -17,7 +17,7 @@ export interface INGXLoggerConfig {
   level: NgxLoggerLevel;
 
   // metadata-service config
-  /** Timestamp format: any format accepted by Angular DatePipe. Defaults to ISOString */
+  /** Timestamp format: any format accepted by Angular DatePipe. Defaults to ISOString. If set you need to provide DatePipe from @angular/common */
   timestampFormat?: string;
 
   // rule-service config

--- a/src/lib/logger.module.ts
+++ b/src/lib/logger.module.ts
@@ -1,4 +1,4 @@
-import { CommonModule, DatePipe } from '@angular/common';
+import { CommonModule } from '@angular/common';
 import { ClassProvider, ConstructorProvider, ExistingProvider, FactoryProvider, ModuleWithProviders, NgModule, ValueProvider } from '@angular/core';
 
 import { NGXLogger } from './logger.service';
@@ -21,9 +21,6 @@ import { TOKEN_LOGGER_CONFIG_ENGINE_FACTORY } from './config/iconfig-engine-fact
   imports: [
     CommonModule
   ],
-  providers: [
-    DatePipe // DatePipe is required by metadata-service.ts
-  ]
 })
 export class LoggerModule {
   static forRoot(

--- a/src/lib/metadata/metadata.service.ts
+++ b/src/lib/metadata/metadata.service.ts
@@ -1,5 +1,5 @@
 import { DatePipe } from '@angular/common';
-import { Injectable } from '@angular/core';
+import { Injectable, Optional } from '@angular/core';
 import { NgxLoggerLevel } from '../types/logger-level.enum';
 import { INGXLoggerConfig } from '../config/iconfig';
 import { INGXLoggerMetadata } from './imetadata';
@@ -9,8 +9,23 @@ import { INGXLoggerMetadataService } from './imetadata.service';
 export class NGXLoggerMetadataService implements INGXLoggerMetadataService {
 
   constructor(
-    protected readonly datePipe: DatePipe,
+    @Optional() protected readonly datePipe: DatePipe,
   ) { }
+
+  protected computeTimestamp(config: INGXLoggerConfig): string {
+    const defaultTimestamp = () => new Date().toISOString();
+
+    if (config.timestampFormat) {
+      if (!this.datePipe) {
+        console.error('NGXLogger : Can\'t use timeStampFormat because DatePipe is not provided. You need to provide DatePipe');
+        return defaultTimestamp();
+      } else {
+        return this.datePipe.transform(new Date(), config.timestampFormat);
+      }
+    }
+
+    return defaultTimestamp();
+  }
 
   public getMetadata(
     level: NgxLoggerLevel,
@@ -31,12 +46,7 @@ export class NGXLoggerMetadataService implements INGXLoggerMetadataService {
       metadata.message = message;
     }
 
-    if (config.timestampFormat) {
-      metadata.timestamp = this.datePipe.transform(new Date(), config.timestampFormat);
-    } else {
-      metadata.timestamp = new Date().toISOString();
-    }
-
+    metadata.timestamp = this.computeTimestamp(config);
 
     return metadata;
   }


### PR DESCRIPTION
Fixes #293 

This dependency is only needed if timestampFormat is used