### PR TITLE
Improved trace method

### DIFF
--- a/src/lib/logger.service.spec.ts
+++ b/src/lib/logger.service.spec.ts
@@ -36,10 +36,17 @@ describe('NGXLogger', () => {
       [NGXLogger],
       (logger: NGXLogger) => {
         const logSpy = spyOn(<any>logger, '_log');
+        const messageString = 'message';
 
-        logger.trace('message');
-
-        expect(logSpy).toHaveBeenCalledWith(NgxLoggerLevel.TRACE, 'message', []);
+        logger.trace(messageString);
+        const _testStackError = new Error();
+        _testStackError.name = messageString;
+        
+        expect(logSpy).toHaveBeenCalled();
+        expect(logSpy.calls.argsFor(0)[0]).toBe(NgxLoggerLevel.TRACE);
+        // We can't test the exact stack trace so we only make sure the message is included
+        expect(logSpy.calls.argsFor(0)[1]).toContain(messageString);
+        expect(logSpy.calls.argsFor(0)[2]).toEqual([]);
       }
     ));
   });

--- a/src/lib/logger.service.ts
+++ b/src/lib/logger.service.ts
@@ -42,7 +42,12 @@ export class NGXLogger {
   }
 
   public trace(message?: any | (() => any), ...additional: any[]): void {
-    this._log(NgxLoggerLevel.TRACE, message, additional);
+    // We manually set the stack trace using a dummy Error.
+    // This is done instead of using console.trace in _log method to ensure the stack trace is kept at the highest level possible.
+    // If the dummy error has no stack, we default to printing only the message and additional parameters.
+    const _traceDummyError = new Error();
+    _traceDummyError.name = message;
+    this._log(NgxLoggerLevel.TRACE, _traceDummyError.stack || message, additional);
   }
 
   public debug(message?: any | (() => any), ...additional: any[]): void {


### PR DESCRIPTION
I feel the trace method should keep it's original intent to log the current stack trace (same as node.js defautl console.trace)

- Looks like some time ago the default behavior of LoggerService.trace was to call console.trace but this was removed as the stack trace shown was the one of console.trace.
- This PR aims to add back the stack trace, putting it on a higher level so that only 1 extra line is present in the stack trace (LoggerService.trace)
- If somehow the stack trace is not available, the method will revert to its previous behavior and only log the message and additional params
- I did not manage to create a unit test that would succefully check the exact stack trace added in _log method so I'm only making sure the message sent to the method is present in the stack trace. Maybe that can be improved
- Watchout, this change will obviously drastically change the output in console if users where using a lot of LoggerService.trace calls.

![image](https://github.com/dbfannin/ngx-logger/assets/37383113/aa1dac07-2866-4030-ba06-4d9dc265bafe)
